### PR TITLE
Add trading-chart Discord bot with Claude vision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .bundle
+trading-bot/.env
+trading-bot/.venv/
+trading-bot/__pycache__/
+*.pyc

--- a/business-vault/00 - BIZNIS - Glavna mapa znanja.md
+++ b/business-vault/00 - BIZNIS - Glavna mapa znanja.md
@@ -1,0 +1,855 @@
+# 🗺️ BIZNIS — Glavna mapa znanja (MOC)
+
+> Ovo je središnja nota. Sve ostalo je povezano odavde. Redoslijed = stupanj prioriteta.
+> ⚠️ Bot nema pristup tvom Obsidianu. Ovaj fajl je u GitHub repu (`business-vault/`). Pull pa kopiraj u svoj vault.
+
+## Faza 1 — Pročitano (temelj, čuvaj kao referencu)
+- [Atomic Habits — James Clear](#-atomic-habits--james-clear)
+- [Cybernetics — Norbert Wiener](#-cybernetics--norbert-wiener)
+- [⚠️ "Psychology" — koja tačno? (TBD)](#-psychology--koja-tačno-tbd)
+- [48 Laws of Power — Robert Greene](#-48-laws-of-power--robert-greene)
+- [Deep Work — Cal Newport](#-deep-work--cal-newport)
+- [Ultralearning — Scott Young](#-ultralearning--scott-young)
+- [Make It Stick — Brown / Roediger / McDaniel](#-make-it-stick--brown--roediger--mcdaniel)
+- [How to Talk to Anyone — Leil Lowndes](#-how-to-talk-to-anyone--leil-lowndes)
+- [The War of Art — Steven Pressfield](#-the-war-of-art--steven-pressfield)
+- [So Good They Can't Ignore You — Cal Newport](#-so-good-they-cant-ignore-you--cal-newport)
+- [Mastery — Robert Greene](#-mastery--robert-greene)
+
+## Faza 2 — Sljedeće na redu (max impact za tebe kao tradera + samostalnog graditelja)
+- [Trading in the Zone — Mark Douglas](#-trading-in-the-zone--mark-douglas)
+- [Psychology of Money — Morgan Housel](#-psychology-of-money--morgan-housel)
+- [The Almanack of Naval Ravikant — Eric Jorgenson](#-the-almanack-of-naval-ravikant--eric-jorgenson)
+- [Never Split the Difference — Chris Voss](#-never-split-the-difference--chris-voss)
+- [Influence — Robert Cialdini](#-influence--robert-cialdini)
+- [Thinking, Fast and Slow — Daniel Kahneman](#-thinking-fast-and-slow--daniel-kahneman)
+- [Letters from a Stoic — Seneca](#-letters-from-a-stoic--seneca)
+- [Ego is the Enemy — Ryan Holiday](#-ego-is-the-enemy--ryan-holiday)
+- [$100M Offers — Alex Hormozi](#-100m-offers--alex-hormozi)
+
+## Faza 3 — Dnevna rutina (vrtiš u krug, bez kraja)
+- [Meditations — Marcus Aurelius](#-meditations--marcus-aurelius)
+- [Discourses — Epictetus](#-discourses--epictetus)
+
+---
+
+## Kako ovaj sistem radi (mentalni model)
+
+```
+TEMELJI (Faza 1):
+  Atomic Habits + War of Art = SISTEMI
+  Mastery + So Good = KARIJERNA STRATEGIJA
+  Deep Work + Ultralearning + Make It Stick = UČENJE
+  48 Laws + How to Talk to Anyone = LJUDI
+  Psychology of Money + Cybernetics = NOVAC + FEEDBACK SISTEMI
+          │
+SLJEDEĆE (Faza 2):
+  Trading in the Zone + Kahneman = TRADER PSIHOLOGIJA
+  Voss + Cialdini = PREGOVORI + UTJECAJ
+  Naval + Hormozi = LEVERAGE + OFFER CONSTRUCTION
+  Seneca + Ego is the Enemy = STOICIZAM DUBLJE
+          │
+DNEVNO (Faza 3):
+  Meditations + Discourses = JUTARNJI / VEČERNJI RESET
+          │
+REZULTAT:
+  Discipliniran sistem → odluke bez ega → kapital + reputacija → sloboda
+```
+
+## Zlatna pravila (ovog vaulta)
+
+1. **Knjiga koju ne primjenjuješ je zabava, ne investicija.** Svaka pročitana knjiga = minimum 1 konkretna promjena u životu/sistemu.
+2. **Bilješke u svojim riječima, ne highlighti.** Ako ne možeš objasniti djetetu — nisi razumio. → vidi Make It Stick.
+3. **Reread > new read.** Bolje 5x ista odlična knjiga nego 50 prosječnih. Mastery, Meditations, Trading in the Zone = vraćaš se.
+4. **Knjiga + akcija + journal = jedan ciklus.** Nema pravog znanja bez sve tri.
+5. **Sat dnevno čitanja = 365h godišnje = ~30 knjiga = kompetencija expert-level u 3-5 godina.**
+
+> ⚠️ Edukativni materijal i osobna refleksija. Ne financijski savjet.
+
+---
+
+# 🧱 Atomic Habits — James Clear
+
+**Status:** PROČITANO • **Tip:** Habits / System Design
+
+## Centralna teza
+Ne podigneš se na nivo svojih ciljeva — padneš na nivo svojih sistema. Mala navika ponavljana 365 dana = identitet. 1% bolji svaki dan = 37x bolji za godinu.
+
+## Glavne lekcije
+- **4 zakona promjene ponašanja:**
+  1. Učini OČITIM (cue) — postavi tragove ispred sebe.
+  2. Učini PRIVLAČNIM (craving) — pari naviku sa nečim što voliš (temptation bundling).
+  3. Učini LAKIM (response) — pravilo 2 minute, dizajn okoline.
+  4. Učini ZADOVOLJAVAJUĆIM (reward) — odmah, ne kasnije.
+- **Identity-based habits:** ne "želim trčati" nego "ja sam trkač". Glasaj za sebe svaki put kad uradiš naviku.
+- **Habit stacking:** "nakon X, uradit ću Y". Prikači novu naviku na postojeću.
+- **Plateau of latent potential:** rezultati su exponencijalni, ne linearni. Većina odustaje u "dolini razočaranja".
+
+## Mentalni alat (framework)
+```
+Cue → Craving → Response → Reward
+[OČITO]  [PRIVLAČNO]  [LAKO]  [ZADOVOLJAVAJUĆE]
+```
+Postojeća navika? Inverzuj 4 zakona da je razbiješ.
+
+## Kako primijeniti
+- Habit stack za jutro: nakon kafe → 10 min čitanja → 5 min planiranja dana.
+- Habit tracker (Obsidian Daily Note checklist): ne prekidaj lanac.
+- Za trading: "nakon screenshotta setupa → upiši u journal PRIJE entryja".
+
+## Citati
+- "You do not rise to the level of your goals. You fall to the level of your systems."
+- "Every action you take is a vote for the type of person you wish to become."
+
+## Povezano
+- The War of Art (otpor sistemu)
+- So Good They Can't Ignore You (deliberate practice = sistem)
+- Mastery (kompozit dugotrajnih navika)
+
+---
+
+# 🔁 Cybernetics — Norbert Wiener
+
+**Status:** PROČITANO • **Tip:** Systems Thinking / Foundational
+
+## Centralna teza
+Sve što se ponaša svrhovito — živo biće, mašina, organizacija, ti — radi na principu **feedback loop**a: cilj → akcija → mjerenje → korekcija. Bez feedbacka nema kontrole; sa lošim feedbackom = oscilacija ili kolaps.
+
+## Glavne lekcije
+- **Negativni feedback** = stabilizira (termostat, autopilot, dobro vođeni biznis).
+- **Pozitivni feedback** = pojačava (viralnost, hype, panika, kaskade likvidacija).
+- **Delay u feedbacku** = oscilacije. Tržište je sistem s ogromnim delay-om → zato nadmašuju i podmašuju.
+- **Information theory:** signal vs noise. Više podataka ≠ više informacije.
+- Pojam **homeostaze** — sistem koji se aktivno održava unutar zone.
+
+## Mentalni alat
+```
+Cilj ───→ Akcija ───→ Stanje sistema
+  ▲                          │
+  └──── Korekcija ←─── Mjerenje
+              (feedback)
+```
+Ako sistem ne radi: provjeri svaku strelicu. Najčešće: feedback je netačan ili predug.
+
+## Kako primijeniti
+- Trading: tvoj journal JE feedback loop. Bez njega tradaš naslijepo.
+- Biznis: tjedni review (prihod, vrijeme, energija) = mjerenje. Bez njega plovis u krug.
+- Život: jasan cilj + dnevni check = self-cybernetics.
+
+## Citati
+- "We are not stuff that abides, but patterns that perpetuate themselves."
+
+## Povezano
+- Atomic Habits (loops na mikro razini)
+- Psychology of Money (delay feedbacka u tržištu)
+- Mastery (sporo, dugo učenje kao kontinuirani feedback)
+
+---
+
+# ⚠️ "Psychology" — koja tačno? (TBD)
+
+**Status:** PROČITANO • **Tip:** Psihologija • **TREBA SUMMARY**
+
+Rekao si da si pročitao knjigu vezanu za psihologiju ali nisi specificirao koju. Najčešći kandidati za biznis/self-improvement kontekst koji ide uz tvoj raster (Cybernetics + Laws of Power + Deep Work):
+
+| Knjiga | Autor | Zašto bi pristajalo |
+|---|---|---|
+| **Psycho-Cybernetics** | Maxwell Maltz | Direktan nastavak Cybernetics-a Wienera; samoslika kao feedback sistem |
+| **Influence: The Psychology of Persuasion** | Robert Cialdini | 6 principa utjecaja — odlično prije Laws of Power |
+| **Predictably Irrational** | Dan Ariely | Iracionalni biasovi u svakodnevnim odlukama |
+| **Thinking, Fast and Slow** | Daniel Kahneman | System 1 vs 2 (već imam u "sljedeće") |
+| **The Subtle Art of Not Giving a F\*ck** | Mark Manson | Vrijednosti + filtriranje briga |
+| **12 Rules for Life** | Jordan Peterson | Klinička psihologija + smisao |
+| **Power of Now** | Eckhart Tolle | Prezenca, ego kao iluzija |
+
+**TO-DO:** Reci mi tačan naslov i autora — ažuriram ovaj odjeljak punim summary-jem u istom stilu kao ostale. Ako ne znaš tačan naslov, opiši o čemu je bila (centralna teza ili autor) pa ću pogoditi.
+
+## Povezano (placeholder)
+- TBD nakon što potvrdiš naslov
+
+---
+
+# 👑 48 Laws of Power — Robert Greene
+
+**Status:** PROČITANO • **Tip:** Politics / Self-defense
+
+## Centralna teza
+Moć je realnost u svakoj grupi ljudi. Ova knjiga nije priručnik za manipulaciju — to je **detektor** prepoznavanja kad neko koristi ova pravila na tebi. Ko ne vidi igru — pijun u njoj.
+
+## Glavne lekcije (selekcija najkorisnijih)
+- **Zakon 1: Nikad ne nadmaši svog gospodara.** Ako šef misli da si pametniji od njega → ti si prijetnja.
+- **Zakon 3: Sakrij svoje namjere.** Plan koji se zna — plan koji se može blokirati.
+- **Zakon 6: Privuci pažnju po svaku cijenu.** Anonimnost = smrt u biznisu.
+- **Zakon 15: Uništi neprijatelja totalno.** Pola pobjede = doživotni neprijatelj.
+- **Zakon 28: Ulazi u akciju sa odvažnošću.** Sumnja se vidi i bira metu.
+- **Zakon 38: Misli kako želiš, govori kako drugi žele.** Ne propovijedaj svoje mišljenje na pogrešnoj publici.
+- **Zakon 48: Pretpostavi bezobličnost.** Voda pobjeđuje kamen u dugoročnom roku.
+
+## Mentalni alat
+Svaki put kad nešto u biznisu izgleda iracionalno → pitaj: **"Čija pozicija moći se ovdje brani ili gradi?"** 9/10 puta dobiješ odgovor.
+
+## Kako primijeniti
+- Prije svakog sastanka: ko ima šta za izgubiti? Ko želi šta da dokaže?
+- Kad neko iznenada postaje "prijatelj" — pitaj zašto. Iznenadna naklonost = iznenadna potreba.
+- Drži najvažnije karte sakrivene. Glasna ambicija = laka meta.
+
+## Citati
+- "When you show yourself to the world and display your talents, you naturally stir all kinds of resentment, envy, and other manifestations of insecurity."
+
+## Povezano
+- How to Talk to Anyone (jezik moći u svakodnevici)
+- Mastery (Greene nastavak — kako postati nemovan stručnjak)
+- Ego is the Enemy (preventiva da Laws of Power ne pređu u manipulaciju ego-om)
+
+---
+
+# 🎯 Deep Work — Cal Newport
+
+**Status:** PROČITANO • **Tip:** Focus / Productivity
+
+## Centralna teza
+Sposobnost duboke koncentracije je rijetka i vrijedna. Ko može provesti 4h fokusiran na težak kognitivni zadatak — proizvodi 10x više od ko skroluje između notifikacija.
+
+## Glavne lekcije
+- **Deep Work hipoteza:** sposobnost dubokog rada bit će sve traženija kako automatizacija raste.
+- **Attention residue:** prebacivanje između zadataka ostavlja "ostatak pažnje" — zato multitasking truje.
+- **Ritualizacija** > motivacija. Određeno mjesto, vrijeme, pravila → automatski ulazak u deep work.
+- **4 filozofije rada:**
+  1. Monastička (totalna izolacija)
+  2. Bimodalna (blokovi po nekoliko dana)
+  3. Ritmička (svaki dan u isto vrijeme — preporuka za većinu)
+  4. Žurnalistička (deep work na zahtjev — najteže)
+- **Productive meditation:** misli o problemu dok hodaš/voziš/treniraš. Subconscious radi.
+
+## Mentalni alat
+```
+Outputi koji nose karijeru = (intenzitet fokusa) × (sati provedeni u fokusu)
+```
+Multitasking dijeli intenzitet → output pada eksponencijalno.
+
+## Kako primijeniti
+- Blokovi 90 min, telefon u drugu sobu (ne avion mode — fizički dalje).
+- Fixed schedule productivity: posao se završava u 18:00 svaki dan. Limit forsira fokus.
+- Slack/Discord/email NE prvih 90 min dana. Nikad.
+- Trading: backtest i journal su deep work — radi ih u prozor kad si oštar (jutro).
+
+## Citati
+- "Clarity about what matters provides clarity about what does not."
+
+## Povezano
+- Atomic Habits (rituali = navike)
+- Ultralearning (deep work primijenjen na učenje)
+- War of Art (otpor ulasku u deep work)
+
+---
+
+# 🧠 Ultralearning — Scott Young
+
+**Status:** PROČITANO • **Tip:** Learning / Career
+
+## Centralna teza
+Možeš ovladati teškim vještinama (jezik, programiranje, finansije) u mjesecima umjesto godinama ako primijeniš **intensivni, samodirigirani projekt** sa jasnim 9 principa.
+
+## Glavne lekcije — 9 principa
+1. **Metalearning** — uči kako se uči ova konkretna vještina prije nego počneš
+2. **Focus** — duboka koncentracija (vidi Deep Work)
+3. **Directness** — uči tako kako ćeš stvarno koristiti (programer? piši kod, ne čitaj o kodu)
+4. **Drill** — izoluj slabu komponentu, mljevenje u krug
+5. **Retrieval** — testiraj se aktivno, ne re-čitaj pasivno (vidi Make It Stick)
+6. **Feedback** — brzi i konkretni komentar na tvoj output
+7. **Retention** — spaced repetition, overlearning
+8. **Intuition** — gradiš dubinski model, ne mehaničko ponavljanje
+9. **Experimentation** — kad ovladaš osnovama, eksperimentiraj sa svojim stilom
+
+## Mentalni alat
+**Direktnost-Drill loop:** radi pravu stvar (direktnost) → identificiraj najslabiju kariku (drill) → vrati se na pravu stvar. Iteriraj.
+
+## Kako primijeniti
+- Za trading: stop reading 100 indicator articles. Otvori demo račun, izvrši 100 tradeova svojim sistemom, journal svaki. To je directness + retrieval + feedback.
+- Za bilo koju vještinu: napravi 3-mjesečni ultralearning projekt sa jasnim ciljem i deadline-om.
+- Test pred ogledalom: ako moraš objasniti vještinu nekom za 5 minuta, što bi rekao? Rupe = što ne znaš.
+
+## Citati
+- "Ultralearning isn't the path of least resistance. It's the path of greatest return."
+
+## Povezano
+- Make It Stick (znanstvena baza retrievala)
+- Deep Work (fokus = uvjet)
+- Mastery (Ultralearning ubrzava put do majstorstva)
+
+---
+
+# 🧪 Make It Stick — Brown / Roediger / McDaniel
+
+**Status:** PROČITANO • **Tip:** Learning Science
+
+## Centralna teza
+Sve što ti se ČINI da uči te u stvari ne uči. Highlighting, re-reading, masirane sesije = iluzija znanja. Pravo učenje boli — testiranje, isprekidanost, prošireni razmak.
+
+## Glavne lekcije
+- **Retrieval practice > re-reading.** Testiraj se aktivno, čak ako griješiš. Greška + ispravka > pasivno čitanje 10x.
+- **Spaced repetition.** Razmakni ponavljanja u vremenu. Kratkoročno zaboravljanje = dugoročno pamćenje.
+- **Interleaving.** Miješaj teme/tipove problema. Mozak gradi razlikujuće veze.
+- **Elaboration.** Objasni novu informaciju svojim riječima i poveži s onim što već znaš.
+- **Reflection** — pitanja na kraju dana: što sam naučio? Kako ću primijeniti?
+- **Iluzija fluentnosti je opasna.** "Razumijem dok čitam" ≠ "mogu reproducirati za 2 tjedna".
+
+## Mentalni alat
+```
+Lako učenje = lako se zaboravlja.
+Otežaj se NAMJERNO → trajno pamtiš.
+```
+
+## Kako primijeniti
+- Pročitana knjiga? Sutra napiši summary BEZ otvaranja knjige. Greške = mete za reread.
+- Trading koncept? Crtaj ga napamet na papir nakon 1 dan, 3 dana, 1 tjedan, 1 mjesec.
+- Mješaj teme u jednoj sesiji učenja umjesto blokova (npr. 30 min market structure, 30 min volume profile, 30 min psihologija — ne 3 sata istog).
+- Anki/Obsidian flashcards za sve ključne termine.
+
+## Citati
+- "Learning is deeper and more durable when it's effortful."
+
+## Povezano
+- Ultralearning (Make It Stick je znanstveni temelj)
+- Deep Work (fokus + ove tehnike = ozbiljan napredak)
+
+---
+
+# 💬 How to Talk to Anyone — Leil Lowndes
+
+**Status:** PROČITANO • **Tip:** Communication / Networking
+
+## Centralna teza
+92 mikro-tehnika za situacije gdje obični ljudi gube social capital — uvod, smalltalk, prelazak u dublji razgovor, izlazak iz neugodne situacije. Suština: drugi ljudi nisu zainteresirani za tebe — već za sebe. Učini ih protagonistima.
+
+## Glavne lekcije (najjače tehnike)
+- **The Flooding Smile** — kad nekoga upoznaš, ne nasmijaši se odmah. Pogledaj u oči pa POSTUPNO osmijeh — kao da si oduševljen baš ovom osobom.
+- **Sticky Eyes** — drži pogled sekundu duže nego što je udobno, čak i kad se okreneš.
+- **Epiphany Onslaught** — koristi "AHA!" reakcije kao alat. "Aha, sad razumijem zašto si to rekao!" → druga strana se osjeća pametno.
+- **Parroting** — ponovi zadnje 2-3 riječi tipa sa upitnikom. Otvara dublji odgovor bez tebe da forsiraš.
+- **What's-Their-Hot-Button** — prvih 60 sekundi nađi za što se ta osoba pali (posao, dijete, hobi). Ostatak razgovora vrti se oko toga.
+- **Never the Naked Thank You** — uvijek dodaj zašto. "Hvala što si ostao" → "Hvala što si ostao, znam koliko ti je važan vremenski raspored."
+
+## Mentalni alat
+Razgovor = transakcija pažnje. Najbolji "naplate" se time što DAJU pažnju, a ne traže je.
+
+## Kako primijeniti
+- Vježbaj 1 tehniku tjedno dok ne uđe u automatizam.
+- Networking sastanci: cilj nije "dojmiti se" nego "saznati šta druga strana zaista treba".
+- Trading networking (Discord/Telegram zajednice): parroting + epiphany — postaješ omiljen brzo.
+
+## Citati
+- "Being a great conversationalist isn't talking. It's listening so well that people feel heard."
+
+## Povezano
+- 48 Laws of Power (jezik moći)
+- Never Split the Difference (sljedeća razina komunikacije)
+
+---
+
+# ✊ The War of Art — Steven Pressfield
+
+**Status:** PROČITANO • **Tip:** Creative Discipline / Anti-Resistance
+
+## Centralna teza
+Postoji sila zvana **Resistance** koja se buni svaki put kad pokušaš nešto vrijedno (kreativan rad, biznis, treniranje, učenje). Resistance ti uvijek šapće "ne danas". Profesionalac sjedne i radi unatoč Resistance-u. Amater čeka muzu koja ne dolazi.
+
+## Glavne lekcije
+- **Resistance je univerzalan i podmukao.** Što važnija akcija — to jača Resistance.
+- **Amater vs profesionalac:**
+  - Amater radi kad se osjeća inspirirano. Profesionalac radi po rasporedu.
+  - Amater uzima loš dan osobno. Profesionalac zna da je to dio posla.
+  - Amater ostaje u svom svijetu. Profesionalac vodi posao kao posao.
+- **Turn pro:** odluka. Ne talent, ne situacija. Odluka da sjedneš i radiš svaki dan.
+- **Higher Realm:** vjeruj da postoji nešto što ti "dolazi" kad sjedneš — ali dolazi samo onome ko sjedne.
+
+## Mentalni alat
+```
+Što više Resistance osjećaš ka nečemu →
+toliko je važnije za tvoj rast.
+```
+Ono što izbjegavaš = ono što moraš uraditi.
+
+## Kako primijeniti
+- Definiraj "tvoj rad" — što je tvoja najvrednija aktivnost? Sjedne na to PRVU svaki dan.
+- Resistance journal: kad osjetiš da bježiš → upiši što, kad, kako se opravdaš.
+- Trading: Resistance ti šapće "ne radi journal danas" ili "preskoči backtest". To je signal da BAŠ TO moraš.
+
+## Citati
+- "Are you paralyzed with fear? That's a good sign. Fear is good. Fear tells us what we have to do."
+- "The professional has learned that success, like happiness, comes as a by-product of work."
+
+## Povezano
+- Atomic Habits (sistem pobjeđuje Resistance)
+- Mastery (Resistance je test pred svaki sljedeći nivo)
+- Discourses (Stoik kontrolira ono što može — odgovor na Resistance)
+
+---
+
+# 🛠️ So Good They Can't Ignore You — Cal Newport
+
+**Status:** PROČITANO • **Tip:** Career Strategy
+
+## Centralna teza
+"Follow your passion" je opasan savjet. Strast NE prethodi izvanrednoj karijeri — slijedi je. Postani toliko dobar da te ne mogu ignorisati, i tada dobiješ kontrolu, novac i smisao.
+
+## Glavne lekcije
+- **Craftsman mindset vs Passion mindset:** ne pitaj "što mi svijet može dati?" nego "što mogu dati svijetu?"
+- **Career capital:** rijetke i vrijedne vještine = valuta. Akumuliraš ih kroz deliberate practice.
+- **Control trap:** prerano traženje kontrole (mala plata, slobodan vrijeme) prije nego što imaš career capital = propast.
+- **Mission:** prava misija (smisao) zahtijeva da prvo budeš na "razini znanja" — bez kompetencije, ne vidiš pravu misiju.
+- **Little bets:** umjesto velikih skokova, testiraj male projekte oko sebe da otkriješ pravu misiju.
+
+## Mentalni alat
+```
+Strast = funkcija(vrijeme, kompetencija, kontrola).
+Ne biraš "pravu" karijeru — gradiš pravu kroz years of skill compounding.
+```
+
+## Kako primijeniti
+- Za 12 mjeseci: koje 3 specifične vještine bi te učinile rijetkim i vrijednim?
+- Mjeri career capital tjedno: što sam dodao u svoj zbir vještina?
+- Trading: ne preskači "boring" rad (journal, backtest, edge research). To je tvoj career capital.
+
+## Citati
+- "Working right trumps finding the right work."
+
+## Povezano
+- Mastery (logičan nastavak — od kompetencije do majstorstva)
+- Deep Work (alat za izgradnju career capitala)
+- Ultralearning (ubrzanje akumulacije)
+
+---
+
+# 🏆 Mastery — Robert Greene
+
+**Status:** PROČITANO • **Tip:** Career / Lifelong • **REREAD svake godine**
+
+## Centralna teza
+Majstorstvo nije talenat — proces. 3 faze: Apprenticeship (učenik) → Creative-Active (aktivno-kreativna) → Mastery (intuitivna spoznaja). Traje 5-10+ godina ali pruža intuiciju i moć koja izgleda magično.
+
+## Glavne lekcije
+- **Life's Task:** svaki čovjek ima primarnu sklonost. Otkriti je = prva i najvažnija odluka. Inače cijeli život lutaš.
+- **Apprenticeship (5-10 godina):**
+  - Promatraj prvo, djeluj poslije
+  - Vještine prvo, novac drugo
+  - Naprijed-nazad iznad teorije
+  - Pati za zanat
+- **Mentori:** nađi pravog mentora i transformiraj sve što znaš. Pa odbaci mentora kad si spreman.
+- **Social Intelligence:** majstor mora razumjeti ljude — inače političke igre uništavaju karijeru.
+- **Creative-Active faza:** mijenjaš pravila, ne samo igraš ih. Tu mnogi ostaju (mediocre).
+- **Mastery faza:** intuicija. Misliš BEZ riječi. Rješavaš probleme prije nego što ih svjesno vidiš.
+
+## Mentalni alat
+```
+"Time is the magic ingredient. You don't see the seed turning into a plant."
+Compounding fokusa na jednom problemu × 10,000+ sati = nadnaravni rezultati.
+```
+
+## Kako primijeniti
+- Definiraj svoj Life's Task. Što te kao djeteta opčinjavalo? Što ti je dolazilo prirodno?
+- Sljedećih 5 godina dizajniraj kao apprenticeship u toj domeni. Plata sporedna, učenje primarno.
+- Trading: 10,000 sati screen time + journal = mastery. Ne postoji skraćeni put.
+- Reread ovu knjigu svake godine na rođendan. Drugačije ćeš čitati svaki put.
+
+## Citati
+- "The future belongs to those who learn more skills and combine them in creative ways."
+- "Most people in life have an idea of doing something. The few who actually do it are the masters."
+
+## Povezano
+- So Good They Can't Ignore You (kompatibilan framework)
+- Atomic Habits (gradivni blokovi mastery-a)
+- Discourses (filozofska potpora za 10-godišnji put)
+
+---
+
+# 📈 Trading in the Zone — Mark Douglas
+
+**Status:** SLJEDEĆE — **PRIORITET #1 ZA TEBE** • **Tip:** Trading Psychology
+
+## Zašto baš ova prva
+Ti si trader. Sva analiza svijeća i VPVR-a je beskorisna ako tvoja psihologija puca u sweat moment. Ova knjiga je STANDARD za psihologiju tradinga. Kombiniraš je sa svojim SMC sistemom i postaješ neranjiv.
+
+## Centralna teza
+Ti ne tradaš tržište — tradaš svoje vjerovanje o tržištu. Probabilistički mindset (svaki trade je nezavisan; over 100 trades, edge se manifestira) zamjenjuje **emotionalno** investirano predviđanje pojedinačnog trada.
+
+## Glavne lekcije (anticipirano)
+- **5 Fundamental Truths:**
+  1. Sve se može dogoditi.
+  2. Ne moraš znati šta će se desiti sljedeće da bi zaradio.
+  3. Postoji random distribucija između win i loss tradova u bilo kojem skupu varijabli.
+  4. Edge nije ništa više od veće vjerojatnosti jednog ishoda preko drugog.
+  5. Svaki moment na tržištu je jedinstven.
+- **Probabilistic thinking:** ne pitaš "hoće li ovaj trade pobijediti?" — pitaš "ako ovaj sistem igram 100 puta, koja je očekivana vrijednost?"
+- **Self-discipline:** poštivanje pravila kad nije lako = jedina realna prednost.
+
+## Kako primijeniti
+- Prvo čitanje: nakon svakog poglavlja, pauziraj 24h. Razmisli na svojim tradovima.
+- Print 5 Fundamental Truths i nalijepi na monitor.
+- Spoji s journal templateom — psihologija svaki trade.
+
+## Povezano
+- Psychology of Money (probabilistic thinking)
+- Meditations (kontrola onog što kontroliraš = poziciju, ne ishod)
+- Ego is the Enemy (gubitak je informacija, ne uvreda)
+
+---
+
+# 💰 Psychology of Money — Morgan Housel
+
+**Status:** SLJEDEĆE • **Tip:** Money / Behavior
+
+## Zašto baš ova za tebe
+Trader si — ali većina onoga što gubi trader nije analiza nego ponašanje s novcem. Housel zaobilazi tehničku stranu i fokusira se direktno na to. Najlakša "next read" jer je čitljiva i lagana po stilu, a pokriva rupe koje ti tehnička analiza ne može popuniti.
+
+## Centralna teza
+Uspjeh s novcem nije o pameti — o ponašanju. Genijalac može propasti, prosjek koji se drži pravila može postati bogat. Vrijeme + složeni rast + ne raditi gluposti = sve.
+
+## Glavne lekcije
+- **Tail events** dominiraju. Većina trejdova/investicija je nula; nekoliko ekstrema nosi sve.
+- **Save like a pessimist, invest like an optimist.** Štedi kao da će sve propasti, ulaži kao da neće.
+- **Reasonable > rational.** Ne tražiš matematički optimalno rješenje — tražiš ono koje ćeš stvarno SLIJEDITI.
+- **Niko nije lud.** Svako donosi finansijske odluke na osnovu svog životnog iskustva. Tvoje iskustvo nije univerzalno.
+- **Sloboda je najveća dividenda.** Cilj nije više novca — cilj je kontrola nad vlastitim vremenom.
+- **Margin of safety** je sve. Slučajna sreća te nije napravila genijem; slučajna nesreća te nije napravila idiotom.
+
+## Mentalni alat
+```
+Bogatstvo = ono što NE VIDIŠ (uštedi).
+Bogatstvo ≠ skupi auto (to je trošak).
+Dugoročno bogatstvo = preživjeti dovoljno dugo da compounding radi.
+```
+
+## Kako primijeniti
+- Drži emergency fund 6 mjeseci troškova → nikad ne forsiraš loš trade jer ti treba novac.
+- Definiraj svoj "Enough" — koliko ti zaista treba da budeš slobodan. Ispod toga gladuješ za vremenom.
+- Prije ulaska u trade: "mogu li podnijeti 100% gubitak ovog pozicijskog risk-a, fizički i emocionalno?" Ako ne → premala margin of safety.
+
+## Citati
+- "Spending money to show people how much money you have is the fastest way to have less money."
+- "Doing well with money has little to do with how smart you are and a lot to do with how you behave."
+
+## Povezano
+- Cybernetics (compounding = pozitivni feedback)
+- Trading in the Zone (psihologija ide ispred matematike)
+- Naval Almanack (leverage + dugoročno razmišljanje)
+
+---
+
+# 🌊 The Almanack of Naval Ravikant — Eric Jorgenson
+
+**Status:** SLJEDEĆE • **Tip:** Wealth / Wisdom
+
+## Zašto
+Najgušća knjiga o leverage-u i dugoročnom razmišljanju u ~200 stranica. Možeš je pročitati za vikend ali se vraćaš godinama. **Free PDF dostupan legalno** na navalmanack.com.
+
+## Centralna teza
+Bogatstvo se ne stvara prodajom svog vremena. Stvara se izgradnjom assets koji rade bez tebe + leverage (kapital, ljudi, **kod & media**). Sreća je vještina, ne sreća.
+
+## Glavne lekcije (anticipirano)
+- **Specific knowledge:** vještina koja te ne može zamijeniti — može se naučiti samo radeći.
+- **Leverage tipovi:** kapital, rad ljudi, **kod i media** (zadnja dva = permissionless, oba scale-aju bez tebe).
+- **Play long-term games with long-term people.** Reputacija + compounding > brzi dobitak.
+- **Read what you love until you love to read.** Čitanje > sve formalne edukacije.
+- **Sreća:** mir + dovoljno + jasna percepcija = sreća. Ne dolazi izvana.
+
+## Kako primijeniti
+- Identificiraj svoju specific knowledge. Trading je dio, ali što još? Kod? Media? Pisanje?
+- Trader = kapitalni leverage. Razmisli: gdje dodati **media ili kod leverage** povrh tradanja (npr. ovaj Discord bot je leverage).
+- Knjiga + journal entries — pretvori je u "operating manual za bogatstvo".
+
+## Povezano
+- Psychology of Money (compounding)
+- Mastery (specific knowledge = ovladano polje)
+- So Good They Can't Ignore You (career capital ~ specific knowledge)
+
+---
+
+# 🤝 Never Split the Difference — Chris Voss
+
+**Status:** SLJEDEĆE • **Tip:** Negotiation
+
+## Zašto
+Bivši FBI hostage negotiator. Tehnike koje su spašavale živote sad rade za biznis pregovore, plate, partnerstva. Praktične TONIGHT — ne teoretsko.
+
+## Centralna teza
+"Win-win" je naivnost. Prava pregovaranja koriste **taktičku empatiju** — razumiješ drugu stranu toliko da MORA dati ti što tražiš jer se osjeća viđenom.
+
+## Glavne lekcije (anticipirano)
+- **Mirroring:** ponovi zadnje 3 riječi tipa sa intonacijom pitanja. Stane, dodaje detalje.
+- **Labeling:** "Čini se kao da je vama važno X." Iznosiš njihove emocije naglas → smanjuje im moć.
+- **"That's right" > "You're right."** "You're right" znači "sad odlazi". "That's right" znači "razumio si me u potpunosti".
+- **Calibrated questions:** "Kako bih mogao raditi to za tu cijenu?" — daje ti drugu stranu da rješava tvoj problem.
+- **Black Swans:** 3-4 nepoznate informacije koje, ako saznaš, promijene cijeli pregovor.
+
+## Kako primijeniti
+- Vježbaj mirroring na svakom telefonskom razgovoru tjedno. Otključava nevjerovatne detalje.
+- Pregovor o plati / suradnji: pripremi 3 calibrated pitanja PRIJE.
+- Trading negotiation sa samim sobom: kad razmišljaš o izlasku, "Kako bih razumio zašto sam stvarno ovdje?"
+
+## Povezano
+- How to Talk to Anyone (osnove)
+- Influence (paralelni framework)
+- 48 Laws of Power (politička strana)
+
+---
+
+# 🎭 Influence — Robert Cialdini
+
+**Status:** SLJEDEĆE • **Tip:** Persuasion / Psychology
+
+## Zašto
+6 univerzalnih okidača utjecaja. Svi ih koriste na tebi (marketing, šefovi, partneri, ti sam na sebi). Ne čitaš — gledaš svijet drugačije zauvijek.
+
+## Centralna teza
+Ljudski mozak ima šortkat **"klik-vrti"** reakcije — ne procesira sve informacije, već koristi 6 mentalnih shortcuteva. Ko zna ovih 6 → vidi manipulaciju i koristi je etički.
+
+## 6 principa
+1. **Reciprocity** — primiš = osjećaš da moraš vratiti. (Free trial, free e-book — svi to igraju.)
+2. **Commitment & Consistency** — kad jednom javno kažeš da ćeš nešto — moraš to ispoštovati.
+3. **Social Proof** — radimo što drugi rade, posebno u neizvjesnosti.
+4. **Liking** — kupujemo od onih koje volimo, koji su slični nama.
+5. **Authority** — povjerenje u titule, uniforme, ekspertizu.
+6. **Scarcity** — što manje dostupno → to više želimo. ("Samo još 3 mjesta!")
+
+## Kako primijeniti
+- Identificiraj koji ti se principi koriste DANAS (oglasi, social, šef). Vježba awareness.
+- Trading: scarcity te tjera u FOMO ulazak. Prepoznaj okidač → vrati se sistemu.
+- Pregovori: oslobađaj reciprocitet (daj prije nego što tražiš), gradi liking, koristi social proof (case studies).
+
+## Povezano
+- 48 Laws (manipulacija na makro razini)
+- Never Split the Difference (komplementaran toolset)
+- How to Talk to Anyone (liking princip primijenjen)
+
+---
+
+# ⚖️ Thinking, Fast and Slow — Daniel Kahneman
+
+**Status:** SLJEDEĆE • **Tip:** Cognitive Bias / Psychology • Nobelovac
+
+## Zašto
+Trader bez znanja o kognitivnim biasima = avion bez instrumenata. Ovo je biblija ljudskog donošenja loših odluka.
+
+## Centralna teza
+Imamo 2 sistema mišljenja:
+- **System 1:** brz, intuitivan, automatski, emotivan (svaki impuls trade).
+- **System 2:** spor, analitičan, naporan, racionalan (tvoja checklista).
+Većinu odluka donosi System 1 a misliš da je System 2. Tu su biasovi.
+
+## Najvažniji biasovi za tradera
+- **Anchoring:** prvi broj koji vidiš te sidri. (Cijena ulaska postaje "fer cijena".)
+- **Availability heuristic:** ono što ti pamet brzo daje = ono što SMATRAŠ vjerojatnim.
+- **Loss aversion:** gubitak boli 2x više nego što dobitak veseli. Tjera te da držiš gubitnike, prerano izlaziš iz pobjednika.
+- **Confirmation bias:** vidiš samo signal koji potvrđuje tvoju tezu.
+- **Overconfidence:** 90% vozača misli da je iznad prosjeka. 90% tradera također.
+- **Hindsight bias:** "znao sam!" → otrov za učenje iz tradova.
+
+## Kako primijeniti
+- Pre-mortem: prije ulaska u trade, zamisli da je propao. Što je pošlo po zlu? → smanji loss aversion.
+- Devil's advocate: nakon analize, namjerno traži signale protiv svog smjera.
+- Journal sa pitanjem "Kojem biasu sam podlegao u ovom tradu?" — kategoriziraj greške.
+
+## Povezano
+- Trading in the Zone (psihologija primijenjena na trading)
+- Psychology of Money (biasovi oko novca)
+- Influence (Cialdinijevi principi = exploit biasova)
+
+---
+
+# 🏛️ Letters from a Stoic — Seneca
+
+**Status:** SLJEDEĆE • **Tip:** Stoicism / Philosophy
+
+## Zašto
+Imaš Marcusa (vladar) i Epicteta (rob). Seneca je TREĆI stoik (savjetnik cara, trgovac, bogati izgnanik). Njegov ugao = praktični stoik u biznisu i ljudskoj politici. Pisma su kratka — 1 dnevno.
+
+## Centralna teza
+Život je dovoljno dug ako znaš kako ga koristiti. Većina ljudi živi kao da imaju vječnost a prosipaju vrijeme na trivije. Filozofija nije akademija — alat za danas.
+
+## Najjača pisma za biznis
+- **On the Shortness of Life** — kraljevski esej, čitaj prvo. Nije ti malo vremena, ti rasipaš.
+- **On Festivals and Fasting** — pripremaj se za gubitak time što ga povremeno simuliraš. (Spavaj na podu jednu noć. Jedi samo kruh dan. → strah te više ne kontrolira.)
+- **On Crowds** — masa kvari karakter. Što više vremena s drugima, manje sa sobom.
+- **On the Reasons for Withdrawing from the World** — kada se povući iz društvene buke da bi mislio.
+
+## Kako primijeniti
+- 1 pismo svako jutro uz kavu. 6 mjeseci → svjetonazor izmijenjen.
+- Praktikuj "negative visualization" tjedno: što ako ovo izgubim sutra? → smanjuje attachment.
+- Journal entry: koje od svojih reakcija danas bi Seneca nazvao "pasiviziranim ropstvom"?
+
+## Citati
+- "It is not that we have a short time to live, but that we waste a lot of it."
+
+## Povezano
+- Meditations (3 stoika = sveto trojstvo)
+- Discourses (Epictetus uči, Seneca aplicira)
+- Ego is the Enemy (Ryan Holiday je sve crpio odavde)
+
+---
+
+# 🚫 Ego is the Enemy — Ryan Holiday
+
+**Status:** SLJEDEĆE • **Tip:** Modern Stoicism / Self-discipline
+
+## Zašto
+Stoicizam za 21. vijek. Tri faze (Aspire → Success → Failure) i kako te ego sruši u svakoj. Brutalno kratka i jasna.
+
+## Centralna teza
+Ego nije confidence. Ego je iluzija veličine bez supstance. Najbolji ljudi u svakom polju su zadržali skromnost — i to im je dalo edge.
+
+## Glavne lekcije
+- **Aspire (kad krećeš):** šuti i radi. Razgovori o planu krade energiju koja treba za izvršenje.
+- **Success (kad uspijeva):** zaboraviš čime si došao tu. Ego ti šapće da ti je tu zaslužen luksuz. Tu padaju.
+- **Failure (kad padaš):** ego osobno uzima poraz. Stoik prihvaća, uči, vraća se.
+- **The Canvas Strategy** — postani nevidljiv alat za druge. Nezamjenjiv pomagač. Sve ostalo dođe.
+- **Always Be a Student.** Kad prestane učiti = pao si, samo još ne znaš.
+
+## Kako primijeniti
+- Pravilo "ne pričaj o planu dok ga ne izvršiš". Anti-Resistance + anti-ego.
+- Nakon win-trade: pitaj "što sam pogriješio?" Nakon loss-trade: pitaš "što sam pogriješio?" Isti pristup → ego ne raste.
+- Tjedni audit: gdje sam danas postupao iz ega? Što sam mogao spustiti?
+
+## Citati
+- "It's not enough to want. Talk depletes us. Action is what counts."
+
+## Povezano
+- War of Art (Pressfield Resistance = Holiday ego)
+- Meditations / Discourses (klasični stoici)
+- Mastery (Greene + Holiday su prijatelji i isti framework)
+
+---
+
+# 💼 $100M Offers — Alex Hormozi
+
+**Status:** SLJEDEĆE • **Tip:** Business / Sales
+
+## Zašto
+Ako ikad budeš nešto prodavao (kurs, signal grupu, mentorstvo, knjigu, bilo šta) — ovo je formula koju koriste najuspješniji. Free PDF dostupan legalno na acquisition.com.
+
+## Centralna teza
+Većina poduzetnika prodaje **commodity** ofertu i konkurira cijenom. Ti praviš "**Grand Slam Offer**" — ofertu tako vrijednu da klijent osjeća krivnju ako ne kupi. Ne konkuriraš — definiraš tržište.
+
+## Glavne lekcije
+- **Value Equation:**
+  ```
+  Vrijednost = (Dream Outcome × Likelihood) / (Time delay × Effort)
+  ```
+  Da povećaš vrijednost: poveća snove + vjerojatnost, smanji vrijeme + napor klijenta.
+- **The Cost of Inaction:** prodaješ klijentu trošak NE-kupovine, ne vrijednost kupovine.
+- **Naming framework:** dobro ime ofere = 50% prodaje. "MAGIC" formula: Magnetic + Avatar + Intriguing + Container + Outcome.
+- **Guarantees:** snažna garancija eliminira rizik = otključava 3-10x prodaje.
+
+## Kako primijeniti
+- Čak i ako ne prodaješ trenutno: koristi Value Equation da evaluiraš svaki proizvod koji KUPIŠ.
+- Razmisli o svojim postojećim vještinama (trading, programming, prevođenje, bilo šta) → kako napraviti Grand Slam offer oko jedne od njih.
+- Pisma + offer copy = leverage (Naval).
+
+## Povezano
+- Influence (Cialdinijevi okidači unutar offer-a)
+- So Good They Can't Ignore You (gradiš najprije skill, pa offer)
+- Naval Almanack (offer = leverage kroz media)
+
+---
+
+# 🧘 Meditations — Marcus Aurelius
+
+**Status:** DNEVNA RUTINA • **Tip:** Stoic Daily Practice • **VRTIŠ U KRUG ZAUVIJEK**
+
+## Pojam
+Privatni dnevnik najmoćnijeg čovjeka rimskog carstva (cara). Pisao ga je sebi, NIKADA nije planirao da se objavi. Zato je sirov, ponavljajuć, i tako koristan.
+
+## Centralna teza
+Ti ne kontroliraš svijet — kontroliraš svoju reakciju na njega. Sve što te uznemiruje izvana je samo tvoja percepcija. Promijeni percepciju → mijenjaš stvarnost koju doživljaš.
+
+## Glavne teme (vraćaš se godinama)
+- **Dichotomy of control:** ono što kontroliraš (sud, namjera, akcija) vs ono što NE (rezultat, mišljenje drugih, vrijeme).
+- **Memento mori:** sjeti se da si smrtan. Ne sutra — DANAS može biti zadnji dan. Trivialnosti nestanu.
+- **Sub specie aeternitatis:** s gledišta vječnosti, ovaj problem je zrno prašine. Skala mijenja sve.
+- **Dužnost > zadovoljstvo.** Ujutro ustani kao čovjek koji ima POSAO. Ne kao komad koji se okreće u krevetu.
+- **Sve je promjena.** Sve se već dogodilo, sve će se ponoviti. Tvoj problem nije nov.
+- **Razumna duša ne mrzi nikoga.** Loši ljudi nisu zli — neznali su za bolje.
+
+## Kako primijeniti (dnevni protokol)
+- **Jutro (5 min):** pročitaj 1 random pasus. Ne dva. Daj mu da odjekuje cijeli dan.
+- **Memento mori večernja:** prije sna, "Šta sam danas uradio od vrijednosti? Da je danas zadnji dan, bih li bio zadovoljan?"
+- **Svaki trenutak iritacije:** pitaj "kontroliram li ovo?" Ako ne → pusti. Ako da → akcija sad.
+- **Reread cijelo (1-2 sata):** svaka 3 mjeseca. Drugi put nego prvi.
+
+## Citati za pamtiti
+- "You have power over your mind — not outside events. Realize this, and you will find strength."
+- "Waste no more time arguing what a good man should be. Be one."
+- "The impediment to action advances action. What stands in the way becomes the way."
+- "If it is not right, do not do it; if it is not true, do not say it."
+
+## Povezano
+- Discourses (Epiktet — Marcusov učitelj filozofski)
+- Letters from a Stoic (Seneca — treći stoik)
+- War of Art (Resistance vs Stoik response)
+- Trading in the Zone (dichotomy of control = trading koren)
+
+---
+
+# 🗣️ Discourses — Epictetus
+
+**Status:** DNEVNA RUTINA • **Tip:** Stoic Daily Practice • **VRTIŠ U KRUG ZAUVIJEK**
+
+## Pojam
+Epictetus je bio rob → oslobođen → najveći stoik učitelj. NIKADA nije sam napisao knjigu — njegov učenik Arrian je zapisivao predavanja. Zato Discourses zvuče kao razgovor, ne traktat.
+
+## Centralna teza
+Slobodan si onoliko koliko si ovladao svojim sudovima. Vlasništvo, slava, pa i vlastito tijelo — sve je posuđeno. Ono što je TVOJE = tvoj odabir kako protumačiti i odgovoriti.
+
+## Glavne teme
+- **Što je naše, što nije naše.**
+  - **Naše:** mišljenje, impuls, želja, averzija — sve unutar uma.
+  - **Nije naše:** tijelo, posjed, reputacija, položaj — sve izvan uma.
+  - Mjeri li tvoja sreća to što je nije tvoje → robuješ.
+- **Filozofija = praksa, ne intelektualne vježbe.** Nije važno koliko si pročitao, nego koliko si proveo u test.
+- **Brzi odgovori uznemirenosti** — udari na percepciju ODMAH, ne nakon sat vremena prepiranja.
+- **Treniraj sebe na neugodnom.** Ako se ne navikneš kontrolirati apetit kad nije izazov, kako ćeš kad bude?
+- **Uloga koju igraš:** odlučio si ulogu (trader, partner, brat, građanin). Igraj je s dignitetom. Ne biraj ulogu — biraš samo kako je igraš.
+
+## Kako primijeniti (dnevni protokol)
+- **Jutro:** "Što danas mogu kontrolirati? Šta moram pustiti?" — 2-minutni mental warmup.
+- **Trigger točke:** kad ti netko uradi nešto što te ljuti, pitaj "tko je vladar tvog uma — ja ili on?"
+- **Tjedni "voluntary discomfort":** hladan tuš, gladan dan, no-coffee dan, no-screen dan. Mali otpor = oklop za stvarni.
+- **Reread Enchiridion (sažetak Discoursesa)** — kraći, savršen za putovanja. Drži ga uvijek.
+
+## Citati za pamtiti
+- "It's not what happens to you, but how you react to it that matters."
+- "Wealth consists not in having great possessions, but in having few wants."
+- "Don't explain your philosophy. Embody it."
+- "First say to yourself what you would be; and then do what you have to do."
+
+## Povezano
+- Meditations (Marcus je primijenio Epicteta na praksu)
+- Letters from a Stoic (Seneca = druga strana iste medalje)
+- Ego is the Enemy (Holiday je 90% Epicteta u modernoj jeziku)
+- War of Art (Resistance = ono što nije naše)
+
+---
+
+# 📅 Tjedni i mjesečni review (obavezno)
+
+## Nedjelja (30 min)
+- Koju sam knjigu ovaj tjedan dotaknuo? Koliko vremena?
+- Jedna lekcija koju sam u stvari PRIMIJENIO ovaj tjedan?
+- Koji ego trigger me sruio (Ego is the Enemy framework)?
+- Koje sam Resistance pobijedio (War of Art framework)?
+- Što ću sljedeći tjedan učiniti drugačije?
+
+## Prvog u mjesecu (60 min)
+- Reread MOC (ovaj fajl).
+- Koju knjigu trebam **rereadati** (ako nije pročitana 6+ mj)?
+- Koju sljedeću knjigu počinjem ovaj mjesec? Koje vrijeme blokiram?
+- Dodaj knjigu u "Pročitano" sa NOVIM summary-jem napisanim svojim riječima (Make It Stick princip — retrieval).
+
+## Rođendan / Nova godina
+- **Reread Mastery cijelo** — ovo je tvoj operating manual za sljedećih 365 dana.
+
+---
+
+> ⚠️ **Zlatno pravilo svega:** Knjiga + akcija + journal = jedan ciklus. Bez sve tri, kupuješ iluziju znanja. Sve tri = compounding edge koji nitko ne može kopirati.
+>
+> Ne financijski savjet. Edukativni materijal i osobna refleksija.

--- a/business-vault/00 - BIZNIS - Glavna mapa znanja.md
+++ b/business-vault/00 - BIZNIS - Glavna mapa znanja.md
@@ -6,7 +6,7 @@
 ## Faza 1 — Pročitano (temelj, čuvaj kao referencu)
 - [Atomic Habits — James Clear](#-atomic-habits--james-clear)
 - [Cybernetics — Norbert Wiener](#-cybernetics--norbert-wiener)
-- [⚠️ "Psychology" — koja tačno? (TBD)](#-psychology--koja-tačno-tbd)
+- [Psycho-Cybernetics — Maxwell Maltz](#-psycho-cybernetics--maxwell-maltz)
 - [48 Laws of Power — Robert Greene](#-48-laws-of-power--robert-greene)
 - [Deep Work — Cal Newport](#-deep-work--cal-newport)
 - [Ultralearning — Scott Young](#-ultralearning--scott-young)
@@ -146,26 +146,56 @@ Ako sistem ne radi: provjeri svaku strelicu. Najčešće: feedback je netačan i
 
 ---
 
-# ⚠️ "Psychology" — koja tačno? (TBD)
+# 🪞 Psycho-Cybernetics — Maxwell Maltz
 
-**Status:** PROČITANO • **Tip:** Psihologija • **TREBA SUMMARY**
+**Status:** PROČITANO • **Tip:** Self-Image / Performance Psychology • **Direktan nastavak Cybernetics-a**
 
-Rekao si da si pročitao knjigu vezanu za psihologiju ali nisi specificirao koju. Najčešći kandidati za biznis/self-improvement kontekst koji ide uz tvoj raster (Cybernetics + Laws of Power + Deep Work):
+## Centralna teza
+Mozak ti je goal-seeking **servomehanizam** (kibernetski sistem). Daj mu jasnu metu + opuštenost + jasnu samosliku → automatski navigira ka njoj kao termostat ka temperaturi. Promijeniš samosliku → mijenjaš sve. Bez nje sva ostala tehnika je beskorisna.
 
-| Knjiga | Autor | Zašto bi pristajalo |
-|---|---|---|
-| **Psycho-Cybernetics** | Maxwell Maltz | Direktan nastavak Cybernetics-a Wienera; samoslika kao feedback sistem |
-| **Influence: The Psychology of Persuasion** | Robert Cialdini | 6 principa utjecaja — odlično prije Laws of Power |
-| **Predictably Irrational** | Dan Ariely | Iracionalni biasovi u svakodnevnim odlukama |
-| **Thinking, Fast and Slow** | Daniel Kahneman | System 1 vs 2 (već imam u "sljedeće") |
-| **The Subtle Art of Not Giving a F\*ck** | Mark Manson | Vrijednosti + filtriranje briga |
-| **12 Rules for Life** | Jordan Peterson | Klinička psihologija + smisao |
-| **Power of Now** | Eckhart Tolle | Prezenca, ego kao iluzija |
+## Glavne lekcije
+- **Self-image je glavni regulator.** Sve što kažeš sebi "ne mogu" je samoslika, ne stvarnost. Samoslika postavlja gornju granicu performansa.
+- **Mozak ne razlikuje stvarno iskustvo od vividno zamišljenog.** Vizualiziraj uspjeh u "theatre of the mind" — neurosistem reagira kao da se desilo. Ovo je naučna baza vizualizacije, ne new-age trik.
+- **Success mechanism vs Failure mechanism.** Oba su navike. **Failure mechanism** (FEAR — Frustration, Aggression, Insecurity, Loneliness, Uncertainty, Resentment, Emptiness) sabotira automatski. **Success mechanism** (Sense of direction, Understanding, Courage, Charity, Esteem, Self-confidence, Self-acceptance) navigira ka cilju.
+- **Relaksacija je preduvjet.** Napet sistem ne može pratiti cilj — kao termostat koji svaku sekundu mijenja vrijednost.
+- **21 dana** je minimum za promjenu samoslike (Maltz je popularizirao ovo pravilo).
+- **Prošli neuspjesi su podaci, ne identitet.** "Failure" je informacija servomehanizmu da promijeni kurs, ne presuda nad tobom.
 
-**TO-DO:** Reci mi tačan naslov i autora — ažuriram ovaj odjeljak punim summary-jem u istom stilu kao ostale. Ako ne znaš tačan naslov, opiši o čemu je bila (centralna teza ili autor) pa ću pogoditi.
+## Mentalni alat (framework)
+```
+Tvoj mozak = servomehanizam (kao autopilot aviona):
+    Cilj (jasan i specifičan)
+       │
+       ▼
+    Akcija (automatska, kad je samoslika usklađena)
+       │
+       ▼
+    Feedback (mjeriš odstupanje)
+       │
+       ▼
+    Korekcija (mehanička, NE emocionalna)
+       │
+       └──→ povratak na Cilj
+```
+Kad se kompliciraš ili ulaziš u "trebao bih bolje" — sabotiraš sistem. Pust feedback radi.
 
-## Povezano (placeholder)
-- TBD nakon što potvrdiš naslov
+## Kako primijeniti
+- **Dnevna mentalna kino-vježba (15 min):** zatvori oči, vizualiziraj sebe kako TAČNO i USPJEŠNO radiš ono što treniraš (savršeni trade, savršen razgovor, savršena prezentacija). Neurološki gradiš novu samosliku.
+- **Failure → reset, ne ruminacija.** Kad pogriješiš (trade, razgovor, kod), zapiši CO je krenulo loše (mehanički), pa pređi. Bez emocionalnog ponavljanja.
+- **Samoslika audit:** "Tko ja mislim da sam kao trader/poduzetnik/partner?" Napiši odgovor. Ako je negativan ili strašljiv → identificirao si svoj plafon.
+- **Trading konkretno:** prije svakog tradinga 5 min mentalnog kina — vidiš sebe kako savršeno pratiš checklist, izlaziš na SL bez bola, slaviš plan ne profit. Samoslika "discipliniran trader" → automatske akcije.
+
+## Citati
+- "Within you right now is the power to do things you never dreamed possible."
+- "Don't try to fail-proof your life. Be willing to take risks to win the game of life."
+- "Setting goals is the first step in turning the invisible into the visible."
+
+## Povezano
+- **Cybernetics** (Maltz primjenjuje Wienera direktno na ljudski mozak — par "Cybernetics + Psycho-Cybernetics" je sveti)
+- **Atomic Habits** (samoslika = identitet → habits flow odatle)
+- **Trading in the Zone** (Mark Douglas se direktno oslanja na servomehanizam koncept)
+- **Mastery** (samoslika "majstor" mora prethoditi majstorstvu, ne obrnuto)
+- **Discourses** (Epiktet: ne kontroliraš ishod, kontroliraš sud → identično Maltzu)
 
 ---
 

--- a/trading-bot/.env.example
+++ b/trading-bot/.env.example
@@ -1,0 +1,3 @@
+DISCORD_TOKEN=your-discord-bot-token-from-https://discord.com/developers/applications
+ANTHROPIC_API_KEY=sk-ant-...
+CLAUDE_MODEL=claude-opus-4-7

--- a/trading-bot/README.md
+++ b/trading-bot/README.md
@@ -1,0 +1,74 @@
+# Trading Chart Discord Bot
+
+Drop a chart screenshot into a Discord channel where the bot is online. The bot analyzes it with Claude vision and replies with: verdict, per-indicator reasoning (S/R, order book, volume, MA, L99, bias), a SAFE / RISKY / BAD rating, and a trade plan (entry, SL, TP, R:R).
+
+You describe the L99 setup in the message caption — the bot uses your description rather than guessing what L99 means.
+
+## Setup
+
+### 1. Create a Discord application and bot
+
+1. Go to <https://discord.com/developers/applications> → **New Application**.
+2. Open the **Bot** tab → **Reset Token** → copy the token.
+3. Under **Privileged Gateway Intents**, enable **Message Content Intent**. Required, or the bot will not see attachments.
+4. Under **OAuth2 → URL Generator**, pick scopes `bot` and `applications.commands`, then in **Bot Permissions** enable: `Read Messages/View Channels`, `Send Messages`, `Read Message History`, `Attach Files`. Open the generated URL to invite the bot to your server.
+
+### 2. Get an Anthropic API key
+
+Go to <https://console.anthropic.com/> → **API Keys** → create a key.
+
+### 3. Install and run
+
+```bash
+cd trading-bot
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+# edit .env and fill in DISCORD_TOKEN and ANTHROPIC_API_KEY
+python bot.py
+```
+
+The bot logs `logged in as <name>` when it is ready. Drop a chart image into any channel the bot can see.
+
+## How to use
+
+- Attach a chart screenshot (PNG, JPEG, WEBP, or GIF; ≤ 5 MB).
+- In the message text, describe the L99 setup if it applies (e.g. *"L99: sweep of yesterday low + reclaim with bullish engulfing"*). If you do not describe L99, the bot will report `L99: no description provided` instead of inventing rules.
+- Reply comes back in the same channel.
+
+## Output format
+
+```
+🟢 **Verdict:** BULLISH
+**Confidence:** 72%
+**Bias timeframe:** 1h
+
+**Reasoning**
+- **S/R:** ...
+- **Order book:** ...
+- **Volume:** ...
+- **MA:** ...
+- **L99:** ...
+- **Confluence:** 4 of 6 aligned → moderate-high
+
+**Safety:** SAFE — clear invalidation, R:R 2.4
+
+**Trade plan**
+- Entry: ...
+- Stop Loss: ...
+- Take Profit 1: ...
+- Take Profit 2: ...
+- R:R: 2.4
+
+**Notes:** ...
+
+_Educational analysis only, not financial advice._
+```
+
+## Notes
+
+- The bot only analyzes what is visible in the screenshot. If order-book data, volume, or MAs are not on the chart, it says "not visible" rather than guessing.
+- The system prompt is sent with `cache_control: ephemeral` so repeat calls reuse the cached prefix (~0.1× input cost on hits). Check the logs — `cache_read=...` shows the cache hits.
+- Adaptive thinking is enabled, so the model decides how much to reason per chart.
+- This is not financial advice.

--- a/trading-bot/VPA-Liquidity-Sweep.md
+++ b/trading-bot/VPA-Liquidity-Sweep.md
@@ -1,0 +1,75 @@
+# 🎯 VPA-Liquidity Sweep — Glavni setup (playbook)
+
+> Ovo je izvršni playbook za JEDAN setup. Sve iz vaulta (struktura, likvidnost, VPA, risk) spaja se ovdje u jednu odluku. Long-only.
+
+## Mentalni model (mikrostruktura)
+
+```
+TRADING = igra s nultom sumom
+  informirani (Smart Money) zarađuju od neinformiranih
+        │
+TRŽIŠTE = problem potrage za likvidnošću
+  kupci traže prodavače; veliki igrač NE MOŽE kupiti bez bazena naloga
+        │
+LIKVIDNOST LEŽI na očitim razinama
+  equal lows / equal highs / očiti swingovi = stop-loss bazeni
+        │
+CIJENA IDE PO LIKVIDNOST prije pravog pokreta
+  sweep = insajderi kupuju po "veleprodajnoj cijeni"
+        │
+VOLUMEN = detektor laži (Wyckoff: napor vs rezultat)
+  pokret bez volumena = zamka; sweep + stopping volume = akumulacija
+```
+
+## Zakoni (Wyckoff + VPA)
+
+1. **Napor vs rezultat:** veliki pokret cijene MORA biti potvrđen visokim volumenom. Veliki volumen + mali pomak = apsorpcija (jedna strana upija drugu).
+2. **Proboj bez volumena = fakeout.** Insajderska zamka, ne breakout.
+3. **Stopping volume:** dugi donji fitilj (hammer) + ekstremni volumen na dnu = insajderi zaustavljaju pad i akumuliraju. "Mopping up" završava.
+4. Grafikon nije niz svijeća — **borba za likvidnost** između Smart Money i javnosti.
+
+## Setup: VPA-Liquidity Sweep (long)
+
+### Korak 1 — Narativ (HTF: 1D/1W → zone na 1h/4h)
+- Na Daily/Weekly odredi kamo tržište "želi" ići (gdje leži novac: EQH/EQL).
+- Na 1h/4h označi **očito dno (support)** gdje se cijena odbila više puta → ispod njega sjede stop-lossovi kupaca = **sell-side liquidity**.
+
+### Korak 2 — Sweep (inducement)
+- Čekaj da cijena **agresivno padne ISPOD** tog dna.
+- To NIJE signal za short — to je insajderska kupovina po veleprodajnoj cijeni (aktivirani stopovi = njihova likvidnost).
+- Bez sweepa nema setupa. Ne ulazi na "približavanje zoni".
+
+### Korak 3 — VPA potvrda (LTF: 5m/15m)
+- Prebaci na 5m/15m i traži **Stopping Volume svijeću**:
+  - dugi donji fitilj (fitilj ≥ 2× tijelo), close u gornjoj polovici raspona (hammer/čekić)
+  - volumen ≥ **2×** prosjeka zadnjih 20 svijeća
+- To je X-ray dokaz da insajderi apsorbiraju prodajni pritisak.
+- Bez volumena, proboj dna je samo nastavak pada. S volumenom + fitiljem = akumulacija.
+
+### Korak 4 — Brojke
+- **Entry:** close hammer svijeće (ili retest njenog tijela).
+- **Stop-Loss:** odmah ISPOD fitilja hammer svijeće — to je "prirodni pod" branjen insajderskim volumenom.
+- **Take-Profit:** suprotna strana — prva razina neprobijenih **Equal Highs** (buy-side liquidity).
+- **R:R ≥ 1:2 obavezno.** Ako TP nije bar 2× dalji od SL-a → nema trada.
+- Rizik: max 1–2% računa.
+
+### Zašto radi
+Ne predviđaš smjer — **pratiš tragove novca**. Tržište prvo uzme novac slabim igračima (sweep), volumen potvrdi da su insajderi ušli, ti se voziš s njima do sljedećeg bazena likvidnosti.
+
+## Invalidacija
+- LTF svijeća **zatvori ispod** low-a hammer svijeće → ideja pala, izlaz bez rasprave.
+- Sweep pa slab volumen na odbijanju → nije naš setup, čekaj sljedeći.
+- HTF struktura LL+LH bez znaka preokreta → sweep može biti nastavak distribucije, preskoči.
+
+## Checklist (kopiraj u journal)
+- [ ] HTF narativ: gdje leži likvidnost (EQH iznad kao meta)?
+- [ ] Očito dno na 1h/4h s višestrukim odbijanjima označeno?
+- [ ] Sweep ISPOD dna se dogodio (ne samo dodir)?
+- [ ] 5m/15m hammer: fitilj ≥ 2× tijela, close u gornjoj polovici?
+- [ ] Volumen hammer svijeće ≥ 2× prosjeka 20 svijeća?
+- [ ] SL ispod fitilja, TP na prvim EQH, R:R ≥ 1:2?
+- [ ] Veto: news < 30 min? jurim? nemam stop unaprijed?
+
+Povezano: 00 - TRADING MOC, Liquidity Sweep (Stop Hunt), Volumen, Market Structure (BOS i CHoCH), Risk Management
+
+> ⚠️ Edukativni materijal, ne financijski savjet. Trading nosi rizik gubitka kapitala.

--- a/trading-bot/bot.py
+++ b/trading-bot/bot.py
@@ -89,17 +89,36 @@ ENTRY CHECKLIST sve to spaja u jednu odluku
 Provjeri prvo: vidi li se VPVR / Volume Profile / anchored volume profile na chartu?
 
 ## Slučaj A — VPVR NIJE na chartu
-Daj korisniku **konkretnu uputu gdje da ga postavi**. Anker biraš prema tome šta vidiš na chartu:
+Daj korisniku **konkretnu uputu gdje da ga postavi**. Anker biraš prema tome šta vidiš na chartu.
 
-| Šta vidiš | Anker koji preporučuješ | Šta će vidjeti |
+### OBAVEZNO: broji svijeće od trenutne (krajnje desne) unazad
+
+Korisnik gleda chart i ne zna šta misliš pod "swing low" ako mu ne kažeš TAČAN BROJ svijeća. Zato uvijek:
+
+1. **Prebroji svijeće od trenutne (krajnje desne, najnovije) unazad** do ankerne svijeće. Daj broj.
+2. **Opiši kako ta svijeća izgleda** da je korisnik može vizualno potvrditi (boja, dužina fitilja, tijelo).
+3. **Reci približnu cijenu te svijeće** sa Y-ose ako je čitljiva.
+
+**Pravilan format upute:**
+> *"Postavi Anchored Volume Profile (TradingView → Indicators → "Anchored Volume Profile") počevši od **N-te svijeće** brojano od trenutne (krajnje desne) unazad. Ta svijeća je **[boja]** sa **[opis: dugi donji fitilj / veliko tijelo / sweep wick / itd.]**, na cijeni **~X**. Vuci anker do trenutne svijeće."*
+
+**Primjer dobre upute:**
+> *"Postavi Anchored VP počevši od **47. svijeće** brojano od trenutne unazad. To je zelena svijeća sa dugim donjim fitiljem (sweep wick), low ~41.850, close ~42.200. Vuci do trenutne. Vidjet ćeš POC akumulacije nakon sweepa SSL-a."*
+
+**Loš primjer (NE radi ovako):**
+> ❌ *"Postavi VP od swing lowa do sad"* — koji swing low? Korisnik mora znati TAČNO.
+
+### Anker biraš prema sceni
+
+| Šta vidiš | Anker (N svijeća unazad) | Šta će vidjeti |
 |---|---|---|
-| Jasan swing low pa rast | Anchored VP od tog swing lowa do sad | gdje su kupci akumulirali na dnu, POC akumulacije |
-| Svjež bullish CHoCH (HTF) | Anchored VP od CHoCH svijeće do sad | volume distribucija u novom uptrendu |
-| Range/konsolidaciju | Fixed Range VP preko cijelog rangea | POC, VAH, VAL — gdje će biti reakcija na proboj |
-| Likvidacijski sweep (dug fitilj) | Anchored VP od sweep svijeće do sad | dokaz ko je preuzeo nakon sweepa |
-| HTF (4H/1D) chart bez očitog pivota | VPVR za zadnjih 7 dana (intraday) ili 30 dana (swing) | širi kontekst HVN/LVN klastera |
+| Jasan swing low pa rast | N = broj svijeća od trenutne do dna (dugi donji fitilj) | POC akumulacije na dnu |
+| Svjež bullish CHoCH (HTF) | N = broj svijeća do CHoCH svijeće (prva koja je probila prethodni LH gore) | distribucija u novom uptrendu |
+| Range/konsolidacija | Fixed Range VP — N = broj svijeća od početka rangea | POC, VAH, VAL rangea |
+| Likvidacijski sweep (dug fitilj) | N = broj svijeća do sweep svijeće | ko je preuzeo nakon sweepa |
+| HTF (4H/1D) bez očitog pivota | N = ~42 svijeće (7 dana na 4H) ili ~30 (30 dana na 1D) | širi HVN/LVN kontekst |
 
-Format upute: *"Postavi Anchored Volume Profile (TradingView → indicators → Anchored VWAP/Volume Profile) od svijeće u [datum/sat ili relativno: '5 svijeća lijevo od trenutne'] do trenutne svijeće. Tako ćeš vidjeti POC akumulacije."*
+Ako ne možeš precizno prebrojiti (npr. chart je previše zumiran in/out), reci tačno: *"ne mogu pouzdano prebrojiti svijeće — približno N ± 3"* i opiši vizualne karakteristike svijeće što detaljnije.
 
 Nakon toga: **NE daješ trade plan**. Vraćaš status: **ČEKAJ VPVR** i tražiš novi screenshot s VPVR-om.
 
@@ -179,7 +198,7 @@ Drži ukupno ispod ~1900 znakova. Budi konkretan i specifičan, ne generički.
 
 **Postavi VPVR ovako:**
 - **Tip:** Anchored Volume Profile / Fixed Range VP (TradingView → Indicators → "Volume Profile")
-- **Anker:** <konkretno: "od svijeće na ~[datum/sat ili relativna pozicija na chartu] do trenutne svijeće" — ili "Fixed Range preko zadnjih N svijeća / 7 dana / 30 dana">
+- **Anker:** <OBAVEZNO tačan broj svijeća: "počevši od N-te svijeće brojano od trenutne (krajnje desne) unazad". Dodaj opis ankerne svijeće: boja, fitilj, tijelo. Dodaj približnu cijenu te svijeće sa Y-ose.>
 - **Zašto baš tu:** <jedna rečenica — npr. "želim vidjeti gdje su kupci akumulirali nakon sweepa SSL-a">
 
 **Šta tražim u VPVR-u kad ga pošalješ:**

--- a/trading-bot/bot.py
+++ b/trading-bot/bot.py
@@ -1,0 +1,267 @@
+import asyncio
+import base64
+import logging
+import os
+import re
+
+import aiohttp
+import discord
+from anthropic import AsyncAnthropic
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+MODEL = os.environ.get("CLAUDE_MODEL", "claude-opus-4-7")
+MAX_IMAGE_BYTES = 5 * 1024 * 1024
+SUPPORTED_MEDIA = {
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("trading-bot")
+
+claude = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
+
+SYSTEM_PROMPT = """You are a disciplined senior technical-analysis assistant for crypto and forex traders. The user will send you a screenshot of a trading chart (candlesticks, order book, depth, or a combination) along with an optional caption that may describe the L99 setup or other context. Your job is to read what is actually visible on the image and report a structured, honest, conservative assessment.
+
+# Hard rules
+
+1. ANALYZE ONLY WHAT IS VISIBLE. Never invent indicators, levels, prices, or order-book data that you cannot see in the image. If a piece of information is not visible, write "not visible" for that section rather than guessing.
+2. NEVER fabricate exact numeric prices that are not shown on the chart axes. If you cannot read a precise value, give a range or label it approximate.
+3. Match the verdict to the evidence. If signals conflict, the verdict is NEUTRAL and safety is RISKY. Do not bias toward "safe" or toward a trade just to be helpful.
+4. Use the L99 description the user provides in their message. If they did not describe it, write "L99: no setup description provided — treat as missing" and do not invent rules.
+5. This is educational analysis, not financial advice. Always include the disclaimer line at the end.
+
+# Analysis checklist
+
+For every chart, walk through each of these. If a piece is not visible on the screenshot, say so explicitly.
+
+## 1. Support and resistance
+- Identify horizontal levels where price has reversed or consolidated multiple times.
+- Note the nearest support BELOW current price and the nearest resistance ABOVE current price.
+- Mark psychological round numbers if present.
+- Distinguish strong levels (3+ touches) from weak levels (1–2 touches).
+
+## 2. Order book / depth (only if visible)
+- Bid wall: large clusters of buy orders → support.
+- Ask wall: large clusters of sell orders → resistance.
+- Imbalance: is one side significantly heavier? Heavy bid side = short-term bullish pressure; heavy ask side = bearish pressure.
+- Spoofing watch: very large isolated walls far from spread can be fake — flag if suspicious.
+- If no order book is visible, write "order book: not visible".
+
+## 3. Volume
+- Direction: is volume rising or declining over the visible window?
+- Volume spikes: do they occur at tops/bottoms (capitulation) or on breakouts (confirmation)?
+- Divergence: price making higher highs while volume makes lower highs = weakening trend (bearish divergence). The opposite = bullish divergence.
+- Volume profile / VWAP if shown: note nodes of high volume (acceptance zones) and current price relative to VWAP.
+
+## 4. Moving averages
+- Identify visible MAs by color/label if possible (e.g., 20, 50, 200).
+- Price above MA + MA sloping up = bullish.
+- Price below MA + MA sloping down = bearish.
+- Golden cross (short MA crossing above long MA) = bullish signal. Death cross = bearish.
+- MA acting as dynamic support/resistance: note if price is bouncing off or rejecting an MA.
+
+## 5. Bias (bullish / bearish / neutral)
+- Higher highs + higher lows + price above key MAs = bullish structure.
+- Lower highs + lower lows + price below key MAs = bearish structure.
+- Choppy, no clear structure = neutral / no-trade zone.
+
+## 6. L99 setup
+- Apply the L99 rules exactly as the user described them in this message.
+- If the user did not describe L99, write "L99: no description provided; cannot evaluate".
+- Do not invent L99 rules from your own knowledge.
+
+## 7. Confluence
+- Count how many of (S/R, order book, volume, MA, L99, bias) point the same direction.
+- 4+ aligned → high-confidence setup.
+- 2–3 aligned → moderate.
+- 0–1 aligned or conflicting → low-confidence / no trade.
+
+# Safety rating
+
+- SAFE = strong confluence (4+ aligned), clear invalidation level (stop loss within ~1–2% for crypto majors / ~30–50 pips for FX majors), reward-to-risk ≥ 2.0, no major event risk visible, and trend structure agrees with the trade direction.
+- RISKY = mixed signals, wide stop, R:R between 1.0 and 2.0, or trading against the higher-timeframe trend.
+- BAD = signals conflict, no clear invalidation, R:R < 1.0, choppy / no structure, or entering near a strong opposing level.
+
+If you cannot determine R:R because price levels are not readable, say so and downgrade safety by one notch.
+
+# Output format
+
+Respond using EXACTLY this template, in this order, in Discord-friendly Markdown. Keep it tight — Discord caps replies at 2000 characters per message, so be specific but concise.
+
+**Verdict:** BULLISH / BEARISH / NEUTRAL
+**Confidence:** <integer 0–100>%
+**Bias timeframe:** <best guess from the chart, e.g. 15m / 1h / 4h / 1D — or "unclear">
+
+**Reasoning**
+- **S/R:** <support and resistance lines you can see>
+- **Order book:** <reading, or "not visible">
+- **Volume:** <reading>
+- **MA:** <reading>
+- **L99:** <reading based on the user's description, or "no description provided">
+- **Confluence:** <N of 6 aligned → label>
+
+**Safety:** SAFE / RISKY / BAD — <one-line reason>
+
+**Trade plan**
+- Entry: <price or "wait for X">
+- Stop Loss: <price>
+- Take Profit 1: <price>
+- Take Profit 2: <price or "trail">
+- R:R: <number, e.g. 2.3>
+
+**Notes:** <1–2 short caveats — invalidation conditions, event risk, missing data>
+
+_Educational analysis only, not financial advice. Trade at your own risk._"""
+
+
+def safety_emoji(text: str) -> str:
+    match = re.search(r"\*\*Safety:\*\*\s*(SAFE|RISKY|BAD)", text)
+    if not match:
+        return ""
+    return {"SAFE": "🟢", "RISKY": "🟡", "BAD": "🔴"}[match.group(1)]
+
+
+async def download_image(url: str) -> tuple[str, bytes] | None:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                return None
+            content_type = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            if content_type not in SUPPORTED_MEDIA:
+                return None
+            data = await resp.read()
+            if len(data) > MAX_IMAGE_BYTES:
+                return None
+            return content_type, data
+
+
+async def analyze_chart(media_type: str, image_bytes: bytes, caption: str) -> str:
+    image_b64 = base64.standard_b64encode(image_bytes).decode("ascii")
+    user_text = caption.strip() if caption.strip() else "No caption. Analyze the chart and apply the standard checklist; treat L99 as 'no description provided'."
+
+    response = await claude.messages.create(
+        model=MODEL,
+        max_tokens=2000,
+        thinking={"type": "adaptive"},
+        system=[
+            {
+                "type": "text",
+                "text": SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": image_b64,
+                        },
+                    },
+                    {"type": "text", "text": user_text},
+                ],
+            }
+        ],
+    )
+
+    parts = [block.text for block in response.content if block.type == "text"]
+    text = "\n".join(p for p in parts if p).strip()
+    if not text:
+        text = "_No analysis text returned by the model. Try again with a clearer chart._"
+
+    usage = response.usage
+    log.info(
+        "claude usage: input=%s cache_read=%s cache_create=%s output=%s",
+        usage.input_tokens,
+        getattr(usage, "cache_read_input_tokens", 0),
+        getattr(usage, "cache_creation_input_tokens", 0),
+        usage.output_tokens,
+    )
+    return text
+
+
+def chunk_message(text: str, limit: int = 1990) -> list[str]:
+    if len(text) <= limit:
+        return [text]
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > limit:
+        split = remaining.rfind("\n", 0, limit)
+        if split == -1:
+            split = limit
+        chunks.append(remaining[:split])
+        remaining = remaining[split:].lstrip("\n")
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Client(intents=intents)
+
+
+@client.event
+async def on_ready():
+    log.info("logged in as %s (id=%s)", client.user, client.user.id if client.user else "?")
+
+
+@client.event
+async def on_message(message: discord.Message):
+    if message.author.bot:
+        return
+
+    image_attachments = [
+        a for a in message.attachments
+        if a.content_type and a.content_type.split(";")[0].strip().lower() in SUPPORTED_MEDIA
+    ]
+    if not image_attachments:
+        return
+
+    attachment = image_attachments[0]
+    async with message.channel.typing():
+        downloaded = await download_image(attachment.url)
+        if downloaded is None:
+            await message.reply(
+                f"Couldn't load that image. Make sure it's PNG/JPEG/WEBP/GIF and under {MAX_IMAGE_BYTES // (1024 * 1024)} MB.",
+                mention_author=False,
+            )
+            return
+        media_type, image_bytes = downloaded
+
+        try:
+            analysis = await analyze_chart(media_type, image_bytes, message.content or "")
+        except Exception as exc:
+            log.exception("analysis failed")
+            await message.reply(f"Analysis failed: `{type(exc).__name__}`. Try again in a moment.", mention_author=False)
+            return
+
+        header = safety_emoji(analysis)
+        body = f"{header} {analysis}".strip() if header else analysis
+        chunks = chunk_message(body)
+        await message.reply(chunks[0], mention_author=False)
+        for extra in chunks[1:]:
+            await message.channel.send(extra)
+
+
+async def main():
+    async with client:
+        await client.start(DISCORD_TOKEN)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/trading-bot/bot.py
+++ b/trading-bot/bot.py
@@ -32,6 +32,12 @@ claude = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
 
 SYSTEM_PROMPT = """Ti si discipliniran SMC/ICT trader koji radi po tačno definisanoj metodologiji korisnika. Korisnik šalje screenshot trading chartova. Tvoj zadatak: proći kroz njegovu 8-koračnu Entry Checklistu, primijeniti samo ono što se ZAISTA vidi na slici, i dati strukturisan odgovor na hrvatskom/bosanskom jeziku — istim terminima koje korisnik koristi u svom Obsidian vaultu.
 
+# Specijalno pravilo za ovog korisnika (TVRDO)
+
+- Tradaš SAMO LONG. Short setupe ne nudiš. Ako je context bearish ili HTF struktura LL+LH → izlaz je NEMA TRADA, nikad SHORT.
+- Glavni alat za odluku je **VPVR (Volume Profile Visible Range)** ili anchored volume profile. Ako VPVR nije na chartu, prvi posao ti je reći korisniku GDJE da ga postavi (ankerni event/svijeća) i šta hoće time da vidi. Tek kad je VPVR vidljiv, daješ punu analizu.
+- Cilj svake analize: "Ima li čistu zonu za long ulazak na osnovu volume profila + strukture + sweepa?" Ako ne — kažeš to.
+
 # Tvoja metodologija (mentalni model — fiksiran)
 
 ```
@@ -78,12 +84,46 @@ ENTRY CHECKLIST sve to spaja u jednu odluku
 - **Risk:** R, 1R, R:R, position size, break-even stop, drawdown
 - **Status:** A+ SETUP, VALJAN, RIZIČNO, NEMA TRADA
 
+# KORAK 0 — VPVR (radiš UVIJEK prije ostalih koraka)
+
+Provjeri prvo: vidi li se VPVR / Volume Profile / anchored volume profile na chartu?
+
+## Slučaj A — VPVR NIJE na chartu
+Daj korisniku **konkretnu uputu gdje da ga postavi**. Anker biraš prema tome šta vidiš na chartu:
+
+| Šta vidiš | Anker koji preporučuješ | Šta će vidjeti |
+|---|---|---|
+| Jasan swing low pa rast | Anchored VP od tog swing lowa do sad | gdje su kupci akumulirali na dnu, POC akumulacije |
+| Svjež bullish CHoCH (HTF) | Anchored VP od CHoCH svijeće do sad | volume distribucija u novom uptrendu |
+| Range/konsolidaciju | Fixed Range VP preko cijelog rangea | POC, VAH, VAL — gdje će biti reakcija na proboj |
+| Likvidacijski sweep (dug fitilj) | Anchored VP od sweep svijeće do sad | dokaz ko je preuzeo nakon sweepa |
+| HTF (4H/1D) chart bez očitog pivota | VPVR za zadnjih 7 dana (intraday) ili 30 dana (swing) | širi kontekst HVN/LVN klastera |
+
+Format upute: *"Postavi Anchored Volume Profile (TradingView → indicators → Anchored VWAP/Volume Profile) od svijeće u [datum/sat ili relativno: '5 svijeća lijevo od trenutne'] do trenutne svijeće. Tako ćeš vidjeti POC akumulacije."*
+
+Nakon toga: **NE daješ trade plan**. Vraćaš status: **ČEKAJ VPVR** i tražiš novi screenshot s VPVR-om.
+
+## Slučaj B — VPVR JE na chartu
+Pročitaj sa profila i koristiš u analizi:
+- **POC (Point of Control)** = cijena s najvećim volumenom u rangeu. Magnet i zona reakcije.
+- **VAH / VAL (Value Area High / Low)** = granice gdje se odigralo 70% volumena. Probojem cijena često produžuje, povratak unutar = mean reversion.
+- **HVN (High Volume Node)** = klasteri visokog volumena = support/resistance zone. Cijena se zadržava.
+- **LVN (Low Volume Node)** = praznine. Cijena leti kroz njih.
+
+### Logika za LONG iz VPVR-a
+- ✅ Cijena ISPOD POC-a + dolazi do HVN-a + sweep SSL ispod njega → snažan long signal (povratak na vrijednost).
+- ✅ Cijena IZNAD POC-a + retest VAH-a kao support → trend continuation long.
+- ✅ LVN gap iznad cijene = magnet (cilj za TP), prazan prostor do sljedećeg HVN-a.
+- ❌ Cijena već daleko iznad POC-a + ulazi u nepoznat teritorij bez HVN-a iznad → ne long, jurnja vrha.
+- ❌ POC iznad cijene + cijena pada kroz LVN → nema long, free fall.
+
 # 8-koračna Entry Checklista (proći redom)
 
 ## KORAK 1 — HTF bias (Market Structure)
 - Pogledaj najviši TF na slici. Označi zadnja 3–4 swing high i swing low.
-- HH+HL = long bias. LL+LH = short bias. Equal highs/lows = range. Svjež CHoCH na HTF = STOP, čekaj potvrdu nove strukture.
-- **Pravilo:** trade se traži SAMO u smjeru HTF strukture.
+- HH+HL = long bias = TRAŽIMO long. LL+LH = short bias = NEMA TRADA (mi short ne tradamo). Range = NEMA TRADA dok se ne pojavi BOS gore.
+- Svjež bullish CHoCH na HTF = signal da se priprema long bias, ali čekamo potvrdu (nova HL formirana).
+- **Pravilo:** trade se traži SAMO LONG, i SAMO u uptrend strukturi (ili netom potvrđenom CHoCH gore).
 
 ## KORAK 2 — Mete likvidnosti
 - Označi EQH/EQL i očite swing točke. BSL iznad cijene, SSL ispod.
@@ -102,8 +142,9 @@ ENTRY CHECKLIST sve to spaja u jednu odluku
 - Na LTF (5m/15m): CHoCH u smjeru biasa nakon sweepa.
 - Ako sweep nije bio, ili svijeća zatvara IZNAD/ISPOD razine (pravi breakout bez povratka) → najvjerojatnije nije naš setup.
 
-## KORAK 5 — Potvrda
-- **Volumen (vidljivo):** volume spike (1.5–2x iznad ~20-svijeća prosjeka) na reakciji u zoni? Divergencija? Klimaks volumen?
+## KORAK 5 — Potvrda (volumen + VPVR)
+- **VPVR (ako je na chartu):** je li zona koju gledamo na HVN-u (jaka)? Je li ispod POC-a (cijena ide po vrijednost)? Ima li LVN gap između entryja i TP-a (brz pokret)?
+- **Volume histogram (vidljivo):** volume spike (1.5–2x iznad ~20-svijeća prosjeka) na reakciji u zoni? Divergencija? Klimaks volumen?
 - **Order book (samo ako vidiš panel):** apsorpcija/wall na našoj strani? Bez panela → "nije vidljivo".
 - **Funding/OI (samo ako vidiš):** nismo li na strani pregrijane gomile? Bez panela → "nije vidljivo, provjeri Coinglass".
 
@@ -120,58 +161,81 @@ ENTRY CHECKLIST sve to spaja u jednu odluku
 - [ ] R:R < 1:2?
 - [ ] News event za < 30 min (CPI/FOMC) — korisnik mora to ručno provjeriti.
 
-## KORAK 8 — Zaključak i kategorija
-- **A+ SETUP** — sva 4 kritična koraka (1, 3, 4, 5) ispunjena, konfluencija FVG+OB+sweep, R:R ≥ 1:2.
-- **VALJAN** — bias + zona + trigger + neka potvrda, R:R ≥ 1:2 (možda bez pune konfluencije).
-- **RIZIČNO** — fali jedan važan korak (npr. nema sweepa, slab volumen, R:R točno 1:2 ili nešto malo iznad), ili neka ključna info nije čitljiva.
-- **NEMA TRADA** — svjež CHoCH na HTF u suprotnom smjeru, signali se sukobljavaju, R:R < 1:2, veto trigger, ili chart je previše chaotic.
+## KORAK 8 — Zaključak i kategorija (LONG-only)
+- **A+ SETUP** — bullish HTF struktura, cijena ulazi u HVN/POC zonu s konfluencijom FVG+OB, sweep SSL + bullish CHoCH na LTF, volume spike potvrda, R:R ≥ 1:2.
+- **VALJAN** — bullish bias + zona + trigger, R:R ≥ 1:2, bez pune VPVR/sweep konfluencije.
+- **RIZIČNO** — bullish bias ali fali jedan važan korak (slab volumen, cijena već iznad POC-a u nepoznatom teritoriju, R:R točno 1:2).
+- **NEMA TRADA** — HTF bearish (LL+LH), nismo u zoni, veto trigger, R:R < 1:2, ili chart pokazuje short setup (mi short ne tradamo).
+- **ČEKAJ VPVR** — VPVR nije na chartu. Korisnik mora prvo postaviti VPVR po tvojoj uputi iz KORAKA 0.
 
 # Format odgovora (TAČNO ovaj template, hrvatski/bosanski, Discord markdown)
 
 Drži ukupno ispod ~1900 znakova. Budi konkretan i specifičan, ne generički.
 
-**Verdikt:** LONG / SHORT / NEMA TRADA
+## Ako VPVR NIJE na chartu — koristi OVAJ skraćeni template
+
+**Verdikt:** ČEKAJ VPVR
+**Razlog:** Volume Profile nije postavljen — bez njega ne mogu provjeriti POC / HVN / LVN.
+
+**Postavi VPVR ovako:**
+- **Tip:** Anchored Volume Profile / Fixed Range VP (TradingView → Indicators → "Volume Profile")
+- **Anker:** <konkretno: "od svijeće na ~[datum/sat ili relativna pozicija na chartu] do trenutne svijeće" — ili "Fixed Range preko zadnjih N svijeća / 7 dana / 30 dana">
+- **Zašto baš tu:** <jedna rečenica — npr. "želim vidjeti gdje su kupci akumulirali nakon sweepa SSL-a">
+
+**Šta tražim u VPVR-u kad ga pošalješ:**
+- POC zona (magnet) → <očekivana cijena ako je čitljivo>
+- HVN klasteri ispod cijene = potencijalne demand zone
+- LVN gap iznad cijene = potencijalni TP magnet
+
+**Status:** ČEKAJ VPVR
+Pošalji novi screenshot s VPVR-om i napravit ću punu analizu.
+
+## Ako VPVR JE na chartu (ili svjesno radimo bez njega s napomenom) — koristi PUNI template
+
+**Verdikt:** LONG / NEMA TRADA
 **Pouzdanost:** <0–100>%
 **HTF (bias):** <npr. 4H / 1D / nečitljivo>
 **LTF (entry):** <npr. 5m / 15m / 1H / nečitljivo>
 
 **Razmišljanje (8 koraka)**
-1. **HTF bias:** <HH+HL / LL+LH / range / tranzicija; ima li svjež CHoCH?>
-2. **Likvidnost:** <BSL/SSL — gdje su EQH/EQL i očiti swingovi; je li već bila pokupljena?>
-3. **Zona interesa:** <konkretan FVG/OB/S-R u smjeru biasa, s cijenom ako je čitljiva; konfluencija?>
-4. **Trigger:** <ima li sweepa + CHoCH na LTF? ili još čekamo cijenu u zoni?>
-5. **Potvrda:** <volumen (vidljivo) — spike/divergencija/klimaks. Order book/funding/OI: "nije vidljivo na screenshotu — provjeri ručno">
-6. **Brojke:** <SL razina, TP1/TP2 razine, R:R račun>
-7. **Veto provjera:** <prošli ili ne — koji uvjet "da"?>
-8. **Zaključak:** <jedna rečenica koja sažima cijelu odluku>
+0. **VPVR:** <POC na cijeni X, HVN klasteri na Y i Z, LVN gap između W i V. Cijena je iznad/ispod POC-a.>
+1. **HTF bias:** <HH+HL bullish — long mode / LL+LH bearish — NEMA TRADA / range — čekamo>
+2. **Likvidnost:** <SSL ispod na cijeni X (meta za sweep prije long-a); BSL iznad kao TP magnet>
+3. **Zona interesa:** <konkretan FVG/OB/HVN s cijenom; konfluencija s VPVR-om?>
+4. **Trigger:** <ima li sweepa SSL + bullish CHoCH na LTF? ili još čekamo>
+5. **Potvrda:** <volume spike na reakciji + VPVR kontekst (HVN/POC). Order book/funding/OI: "nije vidljivo">
+6. **Brojke:** <SL ispod sweepa/zone, TP1/TP2 razine, R:R račun>
+7. **Veto provjera:** <prošli ili ne>
+8. **Zaključak:** <jedna rečenica>
 
 **Signali**
-- **Struktura:** bullish / bearish / range — <kratko>
-- **Likvidnost (meta):** <gdje je sljedeći bazen>
-- **Zona aktivna:** <FVG/OB/S-R na cijeni X — ili "nismo u zoni, čekamo">
-- **Trigger:** da (sweep + CHoCH) / ne / čekamo
-- **Volumen:** potvrđuje / ne potvrđuje / divergencija / nije čitljiv
+- **Struktura:** bullish / bearish / range
+- **VPVR:** cijena iznad/ispod POC-a; HVN/LVN raspored
+- **Likvidnost (meta):** <SSL prije, BSL kao TP>
+- **Zona aktivna:** <ime zone i cijena — ili "nismo u zoni">
+- **Trigger:** da / ne / čekamo
+- **Volumen:** potvrđuje / ne potvrđuje / divergencija
 
-**Status:** A+ SETUP / VALJAN / RIZIČNO / NEMA TRADA — <jednom rečenicom zašto>
+**Status:** A+ SETUP / VALJAN / RIZIČNO / NEMA TRADA — <jednom rečenicom>
 
-**Trade plan**
-- Smjer: LONG / SHORT / —
-- Entry: <cijena ili trigger npr. "reakcija u FVG zoni 42.300–42.450 nakon sweepa SSL-a">
-- Stop Loss: <cijena — iza sweepa/zone>
-- TP1: <cijena — najbliža suprotna likvidnost>
-- TP2: <cijena ili "trailing iza strukture">
-- R:R: <broj, npr. 2.3>
-- Rizik: max 1–2% računa (izračunaj svoju position size formulom)
+**Trade plan (samo ako LONG)**
+- Smjer: LONG
+- Entry: <cijena ili trigger>
+- Stop Loss: <cijena ispod sweepa/zone>
+- TP1: <cijena — najbliži BSL ili HVN iznad>
+- TP2: <cijena ili "trailing iza HH">
+- R:R: <broj>
+- Rizik: max 1–2% računa
 
-**Invalidacija:** <konkretno: "1H close ispod X = ideja pala" ili sl.>
+**Invalidacija:** <1H close ispod X = ideja pala>
 
-**Provjeri ručno (nije vidljivo na chartu):** <ako je relevantno: funding/OI, liquidation heatmap, news kalendar>
+**Provjeri ručno:** <funding/OI, liquidation heatmap, news kalendar — ako relevantno>
 
 _Edukativna analiza, nije financijski savjet. Trading nosi rizik gubitka kapitala._"""
 
 
 def safety_emoji(text: str) -> str:
-    match = re.search(r"\*\*Status:\*\*\s*(A\+ SETUP|VALJAN|RIZIČNO|RIZICNO|NEMA TRADA)", text)
+    match = re.search(r"\*\*Status:\*\*\s*(A\+ SETUP|VALJAN|RIZIČNO|RIZICNO|NEMA TRADA|ČEKAJ VPVR|CEKAJ VPVR)", text)
     if not match:
         return ""
     label = match.group(1).upper().replace("Č", "C")
@@ -180,6 +244,7 @@ def safety_emoji(text: str) -> str:
         "VALJAN": "🟢",
         "RIZICNO": "🟡",
         "NEMA TRADA": "🔴",
+        "CEKAJ VPVR": "🔵",
     }.get(label, "")
 
 

--- a/trading-bot/bot.py
+++ b/trading-bot/bot.py
@@ -30,96 +30,98 @@ log = logging.getLogger("trading-bot")
 
 claude = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
 
-SYSTEM_PROMPT = """You are a disciplined senior technical-analysis assistant for crypto and forex traders. The user will send you a screenshot of a trading chart (candlesticks, order book, depth, or a combination) along with an optional caption that may describe the L99 setup or other context. Your job is to read what is actually visible on the image and report a structured, honest, conservative assessment.
+SYSTEM_PROMPT = """You are a disciplined senior price-action trader. The user sends a screenshot of a trading chart. You analyze it using ONLY two things: pure price action and volume. Ignore every other indicator even if it is on the chart (MAs, RSI, MACD, Bollinger, ichimoku, etc.) — pretend they are not there. Read raw candles and the volume histogram. That's it.
 
 # Hard rules
 
-1. ANALYZE ONLY WHAT IS VISIBLE. Never invent indicators, levels, prices, or order-book data that you cannot see in the image. If a piece of information is not visible, write "not visible" for that section rather than guessing.
-2. NEVER fabricate exact numeric prices that are not shown on the chart axes. If you cannot read a precise value, give a range or label it approximate.
-3. Match the verdict to the evidence. If signals conflict, the verdict is NEUTRAL and safety is RISKY. Do not bias toward "safe" or toward a trade just to be helpful.
-4. Use the L99 description the user provides in their message. If they did not describe it, write "L99: no setup description provided — treat as missing" and do not invent rules.
-5. This is educational analysis, not financial advice. Always include the disclaimer line at the end.
+1. ANALYZE ONLY WHAT IS VISIBLE. Never invent candles, levels, or volume bars you cannot see. If something is unreadable, say "not readable" and downgrade confidence.
+2. NEVER fabricate exact numeric prices that are not on the chart axes. If you can only estimate, label it approximate.
+3. Match the verdict to the evidence. If price action and volume disagree, verdict is NEUTRAL and safety is RISKY. Do not push a trade to be helpful.
+4. Show your thinking. The reader wants to understand WHY, not just the answer. Walk through the logic step by step in the Thinking section before giving the verdict.
+5. Educational analysis only, not financial advice. Always end with the disclaimer line.
 
-# Analysis checklist
+# What "price action" means here
 
-For every chart, walk through each of these. If a piece is not visible on the screenshot, say so explicitly.
+Read the candles themselves. Look for:
 
-## 1. Support and resistance
-- Identify horizontal levels where price has reversed or consolidated multiple times.
-- Note the nearest support BELOW current price and the nearest resistance ABOVE current price.
-- Mark psychological round numbers if present.
-- Distinguish strong levels (3+ touches) from weak levels (1–2 touches).
+- **Market structure**: higher highs + higher lows = uptrend. Lower highs + lower lows = downtrend. Equal highs/lows = range. A break of structure (BOS) = a swing high/low breaks. A change of character (CHoCH) = trend reverses (first lower low in an uptrend, or first higher high in a downtrend).
+- **Swing highs and lows**: identify the most recent ones. They are the levels that matter — not arbitrary horizontals.
+- **Key candles**:
+  - Engulfing (large body fully covering previous body, opposite color) → strong reversal signal at a level.
+  - Pin bar / rejection wick (long wick, small body) → rejection of that level.
+  - Doji at a level → indecision, often pre-reversal.
+  - Inside bar → compression, awaiting breakout.
+  - Marubozu (full body, no wicks) → strong continuation.
+- **Liquidity sweeps**: price wicks past an obvious high or low and closes back inside. Stops got hunted. This is one of the strongest price-action signals.
+- **Supply / demand zones**: the last bullish candle before a strong drop = supply. The last bearish candle before a strong rally = demand. Price often reacts on retest.
+- **Fair value gap / imbalance**: a 3-candle pattern where the middle candle leaves a gap between the high of candle 1 and the low of candle 3 (or vice versa). Price tends to fill these.
+- **Trend lines and channels**: only if obvious — connecting at least 3 touches.
+- **Horizontal S/R from price action**: levels where price has reversed multiple times, not lines you draw arbitrarily.
 
-## 2. Order book / depth (only if visible)
-- Bid wall: large clusters of buy orders → support.
-- Ask wall: large clusters of sell orders → resistance.
-- Imbalance: is one side significantly heavier? Heavy bid side = short-term bullish pressure; heavy ask side = bearish pressure.
-- Spoofing watch: very large isolated walls far from spread can be fake — flag if suspicious.
-- If no order book is visible, write "order book: not visible".
+# What "volume" means here
 
-## 3. Volume
-- Direction: is volume rising or declining over the visible window?
-- Volume spikes: do they occur at tops/bottoms (capitulation) or on breakouts (confirmation)?
-- Divergence: price making higher highs while volume makes lower highs = weakening trend (bearish divergence). The opposite = bullish divergence.
-- Volume profile / VWAP if shown: note nodes of high volume (acceptance zones) and current price relative to VWAP.
+Read the volume histogram below the candles. Look for:
 
-## 4. Moving averages
-- Identify visible MAs by color/label if possible (e.g., 20, 50, 200).
-- Price above MA + MA sloping up = bullish.
-- Price below MA + MA sloping down = bearish.
-- Golden cross (short MA crossing above long MA) = bullish signal. Death cross = bearish.
-- MA acting as dynamic support/resistance: note if price is bouncing off or rejecting an MA.
+- **Confirmation**: a breakout candle WITH a volume spike = real. A breakout WITHOUT a volume spike = likely fake/trap.
+- **Climax volume**: a huge volume bar after an extended move = exhaustion. Reversal often follows.
+- **Absorption**: high volume but small candle body = one side is absorbing the other side's orders. The side that absorbs usually wins the next move.
+- **Effort vs result**: big volume + tiny price move = effort wasted, trend weakening. Small volume + big price move = thin liquidity, unreliable.
+- **Divergence**: price makes a higher high but volume makes a lower high = bullish trend weakening (bearish divergence). Opposite for bullish divergence.
+- **Dry-up before breakout**: volume contracting inside a range often precedes a strong move out of the range.
+- **Volume on retests**: a retest of a broken level on LOW volume is healthy (level holds). Retest on HIGH volume = level likely to fail.
 
-## 5. Bias (bullish / bearish / neutral)
-- Higher highs + higher lows + price above key MAs = bullish structure.
-- Lower highs + lower lows + price below key MAs = bearish structure.
-- Choppy, no clear structure = neutral / no-trade zone.
+# Confluence — only two signals matter
 
-## 6. L99 setup
-- Apply the L99 rules exactly as the user described them in this message.
-- If the user did not describe L99, write "L99: no description provided; cannot evaluate".
-- Do not invent L99 rules from your own knowledge.
+- Price Action signal (bullish / bearish / neutral)
+- Volume signal (bullish / bearish / neutral)
 
-## 7. Confluence
-- Count how many of (S/R, order book, volume, MA, L99, bias) point the same direction.
-- 4+ aligned → high-confidence setup.
-- 2–3 aligned → moderate.
-- 0–1 aligned or conflicting → low-confidence / no trade.
+| PA | Volume | Outcome |
+| --- | --- | --- |
+| Bullish | Bullish | High-confidence long |
+| Bearish | Bearish | High-confidence short |
+| Bullish | Neutral | Moderate long |
+| Bearish | Neutral | Moderate short |
+| Bullish | Bearish | NEUTRAL — conflict, no trade |
+| Bearish | Bullish | NEUTRAL — conflict, no trade |
+| Any | Not readable | Downgrade confidence by one notch |
 
 # Safety rating
 
-- SAFE = strong confluence (4+ aligned), clear invalidation level (stop loss within ~1–2% for crypto majors / ~30–50 pips for FX majors), reward-to-risk ≥ 2.0, no major event risk visible, and trend structure agrees with the trade direction.
-- RISKY = mixed signals, wide stop, R:R between 1.0 and 2.0, or trading against the higher-timeframe trend.
-- BAD = signals conflict, no clear invalidation, R:R < 1.0, choppy / no structure, or entering near a strong opposing level.
+- SAFE = both PA and Volume agree, clear invalidation level (a swing high/low to put the stop beyond), R:R ≥ 2.0, current candle is not extended far from the entry zone.
+- RISKY = one signal is clear, the other is neutral or weak; OR R:R between 1.0 and 2.0; OR price is already extended into the move.
+- BAD = signals conflict; OR no clear invalidation; OR R:R < 1.0; OR chart is choppy with no readable structure; OR you'd be entering INTO a swing high/low instead of after a rejection.
 
-If you cannot determine R:R because price levels are not readable, say so and downgrade safety by one notch.
+If you cannot read precise prices for entry/SL/TP, say so and downgrade safety by one notch.
 
 # Output format
 
-Respond using EXACTLY this template, in this order, in Discord-friendly Markdown. Keep it tight — Discord caps replies at 2000 characters per message, so be specific but concise.
+Respond using EXACTLY this template, in this order, in Discord-friendly Markdown. Keep total reply under ~1900 characters. Be specific, not generic.
 
 **Verdict:** BULLISH / BEARISH / NEUTRAL
-**Confidence:** <integer 0–100>%
-**Bias timeframe:** <best guess from the chart, e.g. 15m / 1h / 4h / 1D — or "unclear">
+**Confidence:** <0–100>%
+**Bias timeframe:** <best guess: 5m / 15m / 1h / 4h / 1D — or "unclear">
 
-**Reasoning**
-- **S/R:** <support and resistance lines you can see>
-- **Order book:** <reading, or "not visible">
-- **Volume:** <reading>
-- **MA:** <reading>
-- **L99:** <reading based on the user's description, or "no description provided">
-- **Confluence:** <N of 6 aligned → label>
+**Thinking (step by step)**
+1. **Structure:** <what is the market doing right now — uptrend / downtrend / range / transition? Identify the most recent swing high and swing low.>
+2. **Last meaningful price action:** <name the specific candle or pattern you see, where it formed, and what it usually means. Example: "bullish engulfing on the retest of the swept low at ~42,300">
+3. **What volume says about it:** <does the volume bar under that candle confirm or contradict the price-action signal? Compare to surrounding volume bars.>
+4. **Agreement check:** <do PA and volume point the same way? Quote the two readings.>
+5. **Therefore:** <one-sentence conclusion that justifies the verdict above.>
+
+**Signals**
+- **Price Action:** <bullish / bearish / neutral — one short reason>
+- **Volume:** <bullish / bearish / neutral / not readable — one short reason>
 
 **Safety:** SAFE / RISKY / BAD — <one-line reason>
 
 **Trade plan**
-- Entry: <price or "wait for X">
-- Stop Loss: <price>
-- Take Profit 1: <price>
-- Take Profit 2: <price or "trail">
-- R:R: <number, e.g. 2.3>
+- Entry: <price or trigger, e.g. "on close above 42,500">
+- Stop Loss: <price, placed beyond the relevant swing>
+- Take Profit 1: <price — usually the next opposing swing>
+- Take Profit 2: <price or "trail behind structure">
+- R:R: <number, e.g. 2.4>
 
-**Notes:** <1–2 short caveats — invalidation conditions, event risk, missing data>
+**Invalidation:** <what specific candle/price would prove this thesis wrong>
 
 _Educational analysis only, not financial advice. Trade at your own risk._"""
 

--- a/trading-bot/bot.py
+++ b/trading-bot/bot.py
@@ -30,107 +30,157 @@ log = logging.getLogger("trading-bot")
 
 claude = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
 
-SYSTEM_PROMPT = """You are a disciplined senior price-action trader. The user sends a screenshot of a trading chart. You analyze it using ONLY two things: pure price action and volume. Ignore every other indicator even if it is on the chart (MAs, RSI, MACD, Bollinger, ichimoku, etc.) — pretend they are not there. Read raw candles and the volume histogram. That's it.
+SYSTEM_PROMPT = """Ti si discipliniran SMC/ICT trader koji radi po tačno definisanoj metodologiji korisnika. Korisnik šalje screenshot trading chartova. Tvoj zadatak: proći kroz njegovu 8-koračnu Entry Checklistu, primijeniti samo ono što se ZAISTA vidi na slici, i dati strukturisan odgovor na hrvatskom/bosanskom jeziku — istim terminima koje korisnik koristi u svom Obsidian vaultu.
 
-# Hard rules
+# Tvoja metodologija (mentalni model — fiksiran)
 
-1. ANALYZE ONLY WHAT IS VISIBLE. Never invent candles, levels, or volume bars you cannot see. If something is unreadable, say "not readable" and downgrade confidence.
-2. NEVER fabricate exact numeric prices that are not on the chart axes. If you can only estimate, label it approximate.
-3. Match the verdict to the evidence. If price action and volume disagree, verdict is NEUTRAL and safety is RISKY. Do not push a trade to be helpful.
-4. Show your thinking. The reader wants to understand WHY, not just the answer. Walk through the logic step by step in the Thinking section before giving the verdict.
-5. Educational analysis only, not financial advice. Always end with the disclaimer line.
+```
+LIKVIDNOST je gorivo → cijena se kreće PREMA likvidnosti
+        │
+ORDER BOOK pokazuje gdje likvidnost stoji SADA
+        │
+VOLUMEN potvrđuje je li pokret stvaran ili lažan
+        │
+MARKET STRUCTURE govori SMJER (tko je u kontroli)
+        │
+FVG / ORDER BLOCK govore GDJE ući (zone interesa)
+        │
+RISK MANAGEMENT odlučuje KOLIKO smiješ izgubiti
+        │
+ENTRY CHECKLIST sve to spaja u jednu odluku
+```
 
-# What "price action" means here
+# Zlatna pravila (ne pregovara se)
 
-Read the candles themselves. Look for:
+1. Bez potvrde volumena — pokret je sumnjiv.
+2. Cijena ide po likvidnost PRIJE nego krene u pravom smjeru. Equal highs/lows i očiti swingovi = mete, ne breakout entry.
+3. Max 1–2% rizika po tradeu. Position size izračunava korisnik sam.
+4. Ako ne znaš gdje je stop loss PRIJE ulaska — nema trade-a.
+5. R:R minimalno 1:2, inače trade ne postoji.
 
-- **Market structure**: higher highs + higher lows = uptrend. Lower highs + lower lows = downtrend. Equal highs/lows = range. A break of structure (BOS) = a swing high/low breaks. A change of character (CHoCH) = trend reverses (first lower low in an uptrend, or first higher high in a downtrend).
-- **Swing highs and lows**: identify the most recent ones. They are the levels that matter — not arbitrary horizontals.
-- **Key candles**:
-  - Engulfing (large body fully covering previous body, opposite color) → strong reversal signal at a level.
-  - Pin bar / rejection wick (long wick, small body) → rejection of that level.
-  - Doji at a level → indecision, often pre-reversal.
-  - Inside bar → compression, awaiting breakout.
-  - Marubozu (full body, no wicks) → strong continuation.
-- **Liquidity sweeps**: price wicks past an obvious high or low and closes back inside. Stops got hunted. This is one of the strongest price-action signals.
-- **Supply / demand zones**: the last bullish candle before a strong drop = supply. The last bearish candle before a strong rally = demand. Price often reacts on retest.
-- **Fair value gap / imbalance**: a 3-candle pattern where the middle candle leaves a gap between the high of candle 1 and the low of candle 3 (or vice versa). Price tends to fill these.
-- **Trend lines and channels**: only if obvious — connecting at least 3 touches.
-- **Horizontal S/R from price action**: levels where price has reversed multiple times, not lines you draw arbitrarily.
+# Tvrda pravila analize
 
-# What "volume" means here
+1. Analiziraš SAMO ono što se vidi na screenshotu. Ne izmišljaš svijeće, razine, volumen, order book, funding, OI, news ni heatmape kojih nema na slici.
+2. Ako nešto NE MOŽEŠ vidjeti (npr. order book, funding rate, open interest, liquidation heatmap, news kalendar), piše tačno: "nije vidljivo na screenshotu — provjeri ručno (Coinglass/Bookmap/news)". Ne pogađaš.
+3. Cijene koje navodiš moraju biti čitljive sa Y-ose chartova. Ako su mutne, daješ raspon ili pišeš "približno".
+4. Sve odluke moraju proći kroz checklistu. Ako bilo koji KRITIČAN korak fali → NEMA TRADA.
+5. Ovo je edukativna analiza, NIJE financijski savjet. Završi obaveznim disclaimerom.
 
-Read the volume histogram below the candles. Look for:
+# Termini koje koristiš (i samo te)
 
-- **Confirmation**: a breakout candle WITH a volume spike = real. A breakout WITHOUT a volume spike = likely fake/trap.
-- **Climax volume**: a huge volume bar after an extended move = exhaustion. Reversal often follows.
-- **Absorption**: high volume but small candle body = one side is absorbing the other side's orders. The side that absorbs usually wins the next move.
-- **Effort vs result**: big volume + tiny price move = effort wasted, trend weakening. Small volume + big price move = thin liquidity, unreliable.
-- **Divergence**: price makes a higher high but volume makes a lower high = bullish trend weakening (bearish divergence). Opposite for bullish divergence.
-- **Dry-up before breakout**: volume contracting inside a range often precedes a strong move out of the range.
-- **Volume on retests**: a retest of a broken level on LOW volume is healthy (level holds). Retest on HIGH volume = level likely to fail.
+- **Struktura:** HH, HL, LH, LL, BOS, CHoCH, swing high/low
+- **Bias:** long bias (HH+HL) / short bias (LL+LH) / range / tranzicija
+- **Likvidnost:** BSL (buy-side liquidity, iznad highova), SSL (sell-side liquidity, ispod lowova), EQH (equal highs), EQL (equal lows), sweep, stop hunt, SFP, fakeout, turtle soup
+- **Zone:** FVG (fair value gap / imbalance), IFVG (inverse FVG), CE (consequent encroachment = 50% gapa), OB (order block), breaker block, S/R zona, S/R flip, key level, konfluencija
+- **Volumen:** volume spike, klimaks volumen, divergencija, POC, HVN, LVN, CVD, apsorpcija
+- **Order book (ako vidiš):** bid/ask, spread, depth, wall, spoofing, taker/maker
+- **Futures (ako vidiš):** OI delta, funding rate, squeeze, deleveraging, liquidation cascade
+- **Risk:** R, 1R, R:R, position size, break-even stop, drawdown
+- **Status:** A+ SETUP, VALJAN, RIZIČNO, NEMA TRADA
 
-# Confluence — only two signals matter
+# 8-koračna Entry Checklista (proći redom)
 
-- Price Action signal (bullish / bearish / neutral)
-- Volume signal (bullish / bearish / neutral)
+## KORAK 1 — HTF bias (Market Structure)
+- Pogledaj najviši TF na slici. Označi zadnja 3–4 swing high i swing low.
+- HH+HL = long bias. LL+LH = short bias. Equal highs/lows = range. Svjež CHoCH na HTF = STOP, čekaj potvrdu nove strukture.
+- **Pravilo:** trade se traži SAMO u smjeru HTF strukture.
 
-| PA | Volume | Outcome |
-| --- | --- | --- |
-| Bullish | Bullish | High-confidence long |
-| Bearish | Bearish | High-confidence short |
-| Bullish | Neutral | Moderate long |
-| Bearish | Neutral | Moderate short |
-| Bullish | Bearish | NEUTRAL — conflict, no trade |
-| Bearish | Bullish | NEUTRAL — conflict, no trade |
-| Any | Not readable | Downgrade confidence by one notch |
+## KORAK 2 — Mete likvidnosti
+- Označi EQH/EQL i očite swing točke. BSL iznad cijene, SSL ispod.
+- Pitanje: "Po koju likvidnost cijena ide PRIJE mog pokreta?"
+- Liquidation heatmap (Coinglass) nije vidljiv u screenshotu — naglasi da korisnik to mora ručno provjeriti.
 
-# Safety rating
+## KORAK 3 — Zone interesa (FVG + OB + S/R)
+- Na HTF označi netaknute (svježe) FVG-ove i order blockove u smjeru biasa.
+- Bullish FVG: high svijeće 1 ne dodiruje low svijeće 3 → praznina ispod (long zona).
+- Bullish OB: zadnja crvena svijeća prije snažnog rasta koji napravi BOS gore.
+- Konfluencija (FVG + OB + S/R zona u istom području) = A+ zona. Bez konfluencije = obična zona.
 
-- SAFE = both PA and Volume agree, clear invalidation level (a swing high/low to put the stop beyond), R:R ≥ 2.0, current candle is not extended far from the entry zone.
-- RISKY = one signal is clear, the other is neutral or weak; OR R:R between 1.0 and 2.0; OR price is already extended into the move.
-- BAD = signals conflict; OR no clear invalidation; OR R:R < 1.0; OR chart is choppy with no readable structure; OR you'd be entering INTO a swing high/low instead of after a rejection.
+## KORAK 4 — Trigger
+- Cijena je UŠLA u zonu (ne juri pokret koji već bježi).
+- Idealno: sweep likvidnosti u zoni — fitilj kroz EQH/EQL/swing + svijeća zatvori NAZAD unutar rangea.
+- Na LTF (5m/15m): CHoCH u smjeru biasa nakon sweepa.
+- Ako sweep nije bio, ili svijeća zatvara IZNAD/ISPOD razine (pravi breakout bez povratka) → najvjerojatnije nije naš setup.
 
-If you cannot read precise prices for entry/SL/TP, say so and downgrade safety by one notch.
+## KORAK 5 — Potvrda
+- **Volumen (vidljivo):** volume spike (1.5–2x iznad ~20-svijeća prosjeka) na reakciji u zoni? Divergencija? Klimaks volumen?
+- **Order book (samo ako vidiš panel):** apsorpcija/wall na našoj strani? Bez panela → "nije vidljivo".
+- **Funding/OI (samo ako vidiš):** nismo li na strani pregrijane gomile? Bez panela → "nije vidljivo, provjeri Coinglass".
 
-# Output format
+## KORAK 6 — Brojke (Risk Management)
+- **Stop loss:** iza zone/sweepa, na razini koja invalidira ideju. NIKAD točno iza očite razine (tamo love stopove).
+- **Take profit:** sljedeći bazen likvidnosti (suprotni swing/EQH/EQL) ili HTF zona.
+- **R:R:** mora biti ≥ 1:2. Ako nije → preskači trade.
+- Position size NE računaš (nemaš korisnikov saldo). Samo podsjeti: 1–2% rizika.
 
-Respond using EXACTLY this template, in this order, in Discord-friendly Markdown. Keep total reply under ~1900 characters. Be specific, not generic.
+## KORAK 7 — Brzi veto (ako je IŠTA "da" → NEMA TRADA)
+- [ ] Juri svijeću koja već bježi?
+- [ ] Ulaz iz dosade/osvete (na osnovu situacije na chartu)?
+- [ ] Nema jasnog stopa unaprijed?
+- [ ] R:R < 1:2?
+- [ ] News event za < 30 min (CPI/FOMC) — korisnik mora to ručno provjeriti.
 
-**Verdict:** BULLISH / BEARISH / NEUTRAL
-**Confidence:** <0–100>%
-**Bias timeframe:** <best guess: 5m / 15m / 1h / 4h / 1D — or "unclear">
+## KORAK 8 — Zaključak i kategorija
+- **A+ SETUP** — sva 4 kritična koraka (1, 3, 4, 5) ispunjena, konfluencija FVG+OB+sweep, R:R ≥ 1:2.
+- **VALJAN** — bias + zona + trigger + neka potvrda, R:R ≥ 1:2 (možda bez pune konfluencije).
+- **RIZIČNO** — fali jedan važan korak (npr. nema sweepa, slab volumen, R:R točno 1:2 ili nešto malo iznad), ili neka ključna info nije čitljiva.
+- **NEMA TRADA** — svjež CHoCH na HTF u suprotnom smjeru, signali se sukobljavaju, R:R < 1:2, veto trigger, ili chart je previše chaotic.
 
-**Thinking (step by step)**
-1. **Structure:** <what is the market doing right now — uptrend / downtrend / range / transition? Identify the most recent swing high and swing low.>
-2. **Last meaningful price action:** <name the specific candle or pattern you see, where it formed, and what it usually means. Example: "bullish engulfing on the retest of the swept low at ~42,300">
-3. **What volume says about it:** <does the volume bar under that candle confirm or contradict the price-action signal? Compare to surrounding volume bars.>
-4. **Agreement check:** <do PA and volume point the same way? Quote the two readings.>
-5. **Therefore:** <one-sentence conclusion that justifies the verdict above.>
+# Format odgovora (TAČNO ovaj template, hrvatski/bosanski, Discord markdown)
 
-**Signals**
-- **Price Action:** <bullish / bearish / neutral — one short reason>
-- **Volume:** <bullish / bearish / neutral / not readable — one short reason>
+Drži ukupno ispod ~1900 znakova. Budi konkretan i specifičan, ne generički.
 
-**Safety:** SAFE / RISKY / BAD — <one-line reason>
+**Verdikt:** LONG / SHORT / NEMA TRADA
+**Pouzdanost:** <0–100>%
+**HTF (bias):** <npr. 4H / 1D / nečitljivo>
+**LTF (entry):** <npr. 5m / 15m / 1H / nečitljivo>
+
+**Razmišljanje (8 koraka)**
+1. **HTF bias:** <HH+HL / LL+LH / range / tranzicija; ima li svjež CHoCH?>
+2. **Likvidnost:** <BSL/SSL — gdje su EQH/EQL i očiti swingovi; je li već bila pokupljena?>
+3. **Zona interesa:** <konkretan FVG/OB/S-R u smjeru biasa, s cijenom ako je čitljiva; konfluencija?>
+4. **Trigger:** <ima li sweepa + CHoCH na LTF? ili još čekamo cijenu u zoni?>
+5. **Potvrda:** <volumen (vidljivo) — spike/divergencija/klimaks. Order book/funding/OI: "nije vidljivo na screenshotu — provjeri ručno">
+6. **Brojke:** <SL razina, TP1/TP2 razine, R:R račun>
+7. **Veto provjera:** <prošli ili ne — koji uvjet "da"?>
+8. **Zaključak:** <jedna rečenica koja sažima cijelu odluku>
+
+**Signali**
+- **Struktura:** bullish / bearish / range — <kratko>
+- **Likvidnost (meta):** <gdje je sljedeći bazen>
+- **Zona aktivna:** <FVG/OB/S-R na cijeni X — ili "nismo u zoni, čekamo">
+- **Trigger:** da (sweep + CHoCH) / ne / čekamo
+- **Volumen:** potvrđuje / ne potvrđuje / divergencija / nije čitljiv
+
+**Status:** A+ SETUP / VALJAN / RIZIČNO / NEMA TRADA — <jednom rečenicom zašto>
 
 **Trade plan**
-- Entry: <price or trigger, e.g. "on close above 42,500">
-- Stop Loss: <price, placed beyond the relevant swing>
-- Take Profit 1: <price — usually the next opposing swing>
-- Take Profit 2: <price or "trail behind structure">
-- R:R: <number, e.g. 2.4>
+- Smjer: LONG / SHORT / —
+- Entry: <cijena ili trigger npr. "reakcija u FVG zoni 42.300–42.450 nakon sweepa SSL-a">
+- Stop Loss: <cijena — iza sweepa/zone>
+- TP1: <cijena — najbliža suprotna likvidnost>
+- TP2: <cijena ili "trailing iza strukture">
+- R:R: <broj, npr. 2.3>
+- Rizik: max 1–2% računa (izračunaj svoju position size formulom)
 
-**Invalidation:** <what specific candle/price would prove this thesis wrong>
+**Invalidacija:** <konkretno: "1H close ispod X = ideja pala" ili sl.>
 
-_Educational analysis only, not financial advice. Trade at your own risk._"""
+**Provjeri ručno (nije vidljivo na chartu):** <ako je relevantno: funding/OI, liquidation heatmap, news kalendar>
+
+_Edukativna analiza, nije financijski savjet. Trading nosi rizik gubitka kapitala._"""
 
 
 def safety_emoji(text: str) -> str:
-    match = re.search(r"\*\*Safety:\*\*\s*(SAFE|RISKY|BAD)", text)
+    match = re.search(r"\*\*Status:\*\*\s*(A\+ SETUP|VALJAN|RIZIČNO|RIZICNO|NEMA TRADA)", text)
     if not match:
         return ""
-    return {"SAFE": "🟢", "RISKY": "🟡", "BAD": "🔴"}[match.group(1)]
+    label = match.group(1).upper().replace("Č", "C")
+    return {
+        "A+ SETUP": "🟢",
+        "VALJAN": "🟢",
+        "RIZICNO": "🟡",
+        "NEMA TRADA": "🔴",
+    }.get(label, "")
 
 
 async def download_image(url: str) -> tuple[str, bytes] | None:

--- a/trading-bot/bot.py
+++ b/trading-bot/bot.py
@@ -155,21 +155,24 @@ Pročitaj sa profila i koristiš u analizi:
 - Bullish OB: zadnja crvena svijeća prije snažnog rasta koji napravi BOS gore.
 - Konfluencija (FVG + OB + S/R zona u istom području) = A+ zona. Bez konfluencije = obična zona.
 
-## KORAK 4 — Trigger
-- Cijena je UŠLA u zonu (ne juri pokret koji već bježi).
-- Idealno: sweep likvidnosti u zoni — fitilj kroz EQH/EQL/swing + svijeća zatvori NAZAD unutar rangea.
-- Na LTF (5m/15m): CHoCH u smjeru biasa nakon sweepa.
-- Ako sweep nije bio, ili svijeća zatvara IZNAD/ISPOD razine (pravi breakout bez povratka) → najvjerojatnije nije naš setup.
+## KORAK 4 — Trigger: "VPA-Liquidity Sweep" (GLAVNI IMENOVANI SETUP)
+Ovo je primarni setup ovog korisnika. Tržište je borba za likvidnost: Smart Money prvo uzme novac slabim igračima (sweep), pa tek onda krene pravi pokret. Trigger tražiš ovako:
+- **Sweep:** cijena agresivno padne ISPOD očitog dna (support s više odbijanja na 1h/4h) gdje sjede stop-lossovi kupaca (SSL). Fitilj kroz razinu + zatvaranje NAZAD unutar rangea. To NIJE breakdown — to je insajderska kupovina po veleprodajnoj cijeni.
+- **Stopping Volume svijeća na LTF (5m/15m):** hammer/čekić — donji fitilj ≥ 2× tijela, close u gornjoj polovici raspona, uz **ekstremno visok volumen (≥ 2× prosjeka 20 svijeća)**. To je X-ray dokaz da insajderi apsorbiraju prodajni pritisak ("mopping up" završava).
+- Nakon stopping volume svijeće: bullish CHoCH na LTF = potpuna potvrda.
+- Cijena je UŠLA u zonu (ne juri pokret koji već bježi). Bez sweepa nema setupa — "približavanje zoni" nije trigger.
+- Ako svijeća zatvori ISPOD razine i ostane dolje (pravi breakdown bez povratka) → nije naš setup.
 
-## KORAK 5 — Potvrda (volumen + VPVR)
+## KORAK 5 — Potvrda (VPA + volumen + VPVR)
+- **Wyckoff — napor vs rezultat:** veliki pomak cijene MORA pratiti visok volumen. Proboj/odbijanje uz mali volumen = fakeout/zamka insajdera. Veliki volumen + mali pomak = apsorpcija (strana koja upija obično pobjeđuje).
 - **VPVR (ako je na chartu):** je li zona koju gledamo na HVN-u (jaka)? Je li ispod POC-a (cijena ide po vrijednost)? Ima li LVN gap između entryja i TP-a (brz pokret)?
-- **Volume histogram (vidljivo):** volume spike (1.5–2x iznad ~20-svijeća prosjeka) na reakciji u zoni? Divergencija? Klimaks volumen?
+- **Volume histogram (vidljivo):** stopping volume na hammer svijeći (≥ 2× prosjeka)? Divergencija? Klimaks volumen?
 - **Order book (samo ako vidiš panel):** apsorpcija/wall na našoj strani? Bez panela → "nije vidljivo".
 - **Funding/OI (samo ako vidiš):** nismo li na strani pregrijane gomile? Bez panela → "nije vidljivo, provjeri Coinglass".
 
 ## KORAK 6 — Brojke (Risk Management)
-- **Stop loss:** iza zone/sweepa, na razini koja invalidira ideju. NIKAD točno iza očite razine (tamo love stopove).
-- **Take profit:** sljedeći bazen likvidnosti (suprotni swing/EQH/EQL) ili HTF zona.
+- **Stop loss:** odmah ISPOD fitilja stopping-volume (hammer) svijeće — to je "prirodni pod" branjen insajderskim volumenom. Nikad točno iza očite razine (tamo love stopove).
+- **Take profit:** suprotna strana — prva razina neprobijenih EQH (buy-side liquidity) ili sljedeći HTF bazen likvidnosti.
 - **R:R:** mora biti ≥ 1:2. Ako nije → preskači trade.
 - Position size NE računaš (nemaš korisnikov saldo). Samo podsjeti: 1–2% rizika.
 
@@ -181,7 +184,7 @@ Pročitaj sa profila i koristiš u analizi:
 - [ ] News event za < 30 min (CPI/FOMC) — korisnik mora to ručno provjeriti.
 
 ## KORAK 8 — Zaključak i kategorija (LONG-only)
-- **A+ SETUP** — bullish HTF struktura, cijena ulazi u HVN/POC zonu s konfluencijom FVG+OB, sweep SSL + bullish CHoCH na LTF, volume spike potvrda, R:R ≥ 1:2.
+- **A+ SETUP** — bullish HTF struktura, cijena ulazi u HVN/POC zonu s konfluencijom FVG+OB, puni VPA-Liquidity Sweep trigger (sweep SSL + stopping-volume hammer ≥ 2× volumena + bullish CHoCH na LTF), R:R ≥ 1:2.
 - **VALJAN** — bullish bias + zona + trigger, R:R ≥ 1:2, bez pune VPVR/sweep konfluencije.
 - **RIZIČNO** — bullish bias ali fali jedan važan korak (slab volumen, cijena već iznad POC-a u nepoznatom teritoriju, R:R točno 1:2).
 - **NEMA TRADA** — HTF bearish (LL+LH), nismo u zoni, veto trigger, R:R < 1:2, ili chart pokazuje short setup (mi short ne tradamo).

--- a/trading-bot/ict_scanner.py
+++ b/trading-bot/ict_scanner.py
@@ -7,10 +7,18 @@ Detektira setup iz playbooka VPA-Liquidity-Sweep.md:
      close u gornjoj polovici, volumen >= 2x prosjeka 20 svijeća
   4. Brojke: SL ispod fitilja hammera, TP na prvim equal highs, R:R >= 2
 
+NE TREBA TI RAČUN NI API KLJUČ ni na jednoj burzi za skeniranje:
+čitaju se JAVNI podaci o cijenama — iste svijeće koje TradingView crta.
+EXCHANGE env varijabla bira izvor podataka (default binance; radi i
+bybit, okx, kraken, coinbase... bilo koja ccxt burza) — to je samo
+izvor javnih podataka, ne mjesto gdje imaš račun.
+
 Modovi:
   python ict_scanner.py scan  BTC/USDT           # jedan prolaz, ispiši signal
   python ict_scanner.py watch BTC/USDT ETH/USDT  # petlja: skenira svakih 60 s
   python ict_scanner.py backtest BTC/USDT        # test na povijesnim podacima
+
+Za TradingView integraciju (alerti s tvojih chartova) vidi tv_webhook.py.
 
 Paper trading je DEFAULT. Journal ide u paper_trades.json.
 Pravo izvršenje postoji samo kao eksplicitni opt-in:

--- a/trading-bot/ict_scanner.py
+++ b/trading-bot/ict_scanner.py
@@ -1,0 +1,409 @@
+"""VPA-Liquidity Sweep skener (long-only, ICT/VPA stil).
+
+Detektira setup iz playbooka VPA-Liquidity-Sweep.md:
+  1. HTF (1h/4h): očito dno — klaster swing lowova (equal lows) s više odbijanja
+  2. Sweep: cijena probije ISPOD dna fitiljem pa se vrati unutar rangea
+  3. LTF (15m): stopping-volume hammer — donji fitilj >= 2x tijela,
+     close u gornjoj polovici, volumen >= 2x prosjeka 20 svijeća
+  4. Brojke: SL ispod fitilja hammera, TP na prvim equal highs, R:R >= 2
+
+Modovi:
+  python ict_scanner.py scan  BTC/USDT           # jedan prolaz, ispiši signal
+  python ict_scanner.py watch BTC/USDT ETH/USDT  # petlja: skenira svakih 60 s
+  python ict_scanner.py backtest BTC/USDT        # test na povijesnim podacima
+
+Paper trading je DEFAULT. Journal ide u paper_trades.json.
+Pravo izvršenje postoji samo kao eksplicitni opt-in:
+  LIVE_TRADING=YES_I_UNDERSTAND + EXCHANGE_API_KEY + EXCHANGE_SECRET
+Bez toga se nikad ne šalje nalog na burzu.
+
+Edukativni alat, nije financijski savjet.
+"""
+
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+
+import ccxt
+
+EXCHANGE_ID = os.environ.get("EXCHANGE", "binance")
+HTF = os.environ.get("HTF_TIMEFRAME", "1h")
+LTF = os.environ.get("LTF_TIMEFRAME", "15m")
+
+# Parametri setupa (iz playbooka — mijenjaj ovdje, ne u logici)
+EQUAL_LOW_TOLERANCE = 0.0015   # 0.15% — koliko blizu moraju biti lowovi da budu "equal"
+MIN_LEVEL_TOUCHES = 2          # min odbijanja da dno bude "očito"
+SWING_LOOKBACK = 2             # svijeća lijevo/desno za swing point
+HTF_CANDLES = 300
+LTF_CANDLES = 100
+VOLUME_MULT = 2.0              # stopping volume >= 2x prosjeka
+VOLUME_AVG_WINDOW = 20
+WICK_BODY_RATIO = 2.0          # donji fitilj >= 2x tijela
+MIN_RR = 2.0                   # R:R >= 1:2 obavezno
+RISK_PCT = 0.01                # 1% računa po tradeu (paper)
+PAPER_BALANCE_START = 10_000.0
+JOURNAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "paper_trades.json")
+
+
+@dataclass
+class Signal:
+    symbol: str
+    time: str
+    level: float          # probijeno dno (support)
+    sweep_low: float      # najniža točka sweepa
+    entry: float          # close hammer svijeće
+    stop: float           # ispod fitilja hammera
+    target: float         # prve equal highs iznad
+    rr: float
+    hammer_volume_mult: float
+    note: str
+
+
+def utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def fetch(exchange, symbol: str, timeframe: str, limit: int):
+    """OHLCV -> lista [ts, open, high, low, close, volume]."""
+    return exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+
+
+def swing_lows(candles, lookback=SWING_LOOKBACK):
+    """Indeksi svijeća čiji je low niži od `lookback` susjeda s obje strane."""
+    out = []
+    for i in range(lookback, len(candles) - lookback):
+        low = candles[i][3]
+        if all(low <= candles[j][3] for j in range(i - lookback, i + lookback + 1)):
+            out.append(i)
+    return out
+
+
+def swing_highs(candles, lookback=SWING_LOOKBACK):
+    out = []
+    for i in range(lookback, len(candles) - lookback):
+        high = candles[i][2]
+        if all(high >= candles[j][2] for j in range(i - lookback, i + lookback + 1)):
+            out.append(i)
+    return out
+
+
+def find_liquidity_level(candles):
+    """Nađi 'očito dno': klaster swing lowova unutar tolerancije (equal lows).
+
+    Vraća (razina, broj_dodira) najnižeg klastera s dovoljno dodira, ili None.
+    """
+    lows = [(i, candles[i][3]) for i in swing_lows(candles)]
+    best = None
+    for i, base in lows:
+        cluster = [l for _, l in lows if abs(l - base) / base <= EQUAL_LOW_TOLERANCE]
+        if len(cluster) >= MIN_LEVEL_TOUCHES:
+            level = min(cluster)
+            if best is None or level < best[0]:
+                best = (level, len(cluster))
+    return best
+
+
+def detect_sweep(candles, level: float):
+    """Sweep = neka od zadnjih ~10 svijeća probila ISPOD razine fitiljem,
+    a trenutna cijena je NAZAD IZNAD razine. Vraća (indeks, sweep_low) ili None."""
+    recent = candles[-10:]
+    current_close = candles[-1][4]
+    if current_close <= level:
+        return None  # još smo ispod — breakdown, ne sweep (ili sweep u toku)
+    for offset, c in enumerate(recent):
+        if c[3] < level:
+            return (len(candles) - 10 + offset, c[3])
+    return None
+
+
+def is_stopping_volume_hammer(candle, volumes_before):
+    """Hammer + ekstremni volumen. candle = [ts,o,h,l,c,v]."""
+    _, o, h, l, c, v = candle[:6]
+    body = abs(c - o)
+    lower_wick = min(o, c) - l
+    rng = h - l
+    if rng <= 0 or body <= 0:
+        return (False, 0.0)
+    avg = sum(volumes_before[-VOLUME_AVG_WINDOW:]) / max(len(volumes_before[-VOLUME_AVG_WINDOW:]), 1)
+    vol_mult = v / avg if avg > 0 else 0.0
+    hammer = (
+        lower_wick >= WICK_BODY_RATIO * body      # dugi donji fitilj
+        and c >= l + rng * 0.5                    # close u gornjoj polovici
+        and c > o                                 # zelena (kupci pobijedili)
+    )
+    return (hammer and vol_mult >= VOLUME_MULT, vol_mult)
+
+
+def find_target(candles, entry: float):
+    """TP = najbliži swing high (buy-side liquidity) iznad entryja."""
+    highs = [candles[i][2] for i in swing_highs(candles) if candles[i][2] > entry]
+    return min(highs) if highs else None
+
+
+def scan_symbol(exchange, symbol: str):
+    """Jedan puni prolaz kroz setup. Vraća Signal ili None + razlog."""
+    htf = fetch(exchange, symbol, HTF, HTF_CANDLES)
+    level_info = find_liquidity_level(htf)
+    if not level_info:
+        return None, "nema očitog dna (equal lows) na HTF"
+    level, touches = level_info
+
+    sweep = detect_sweep(htf, level)
+    if not sweep:
+        return None, f"dno na {level:.6g} ({touches} dodira) još nije sweepano"
+    _, sweep_low = sweep
+
+    ltf = fetch(exchange, symbol, LTF, LTF_CANDLES)
+    # tražimo stopping-volume hammer u zadnjih 5 LTF svijeća (svježa potvrda)
+    hammer = None
+    for i in range(len(ltf) - 5, len(ltf)):
+        ok, vol_mult = is_stopping_volume_hammer(ltf[i], [c[5] for c in ltf[:i]])
+        if ok and ltf[i][3] <= level * (1 + EQUAL_LOW_TOLERANCE):
+            hammer = (ltf[i], vol_mult)
+    if not hammer:
+        return None, f"sweep dna {level:.6g} se dogodio, ali nema stopping-volume hammera na {LTF}"
+    hammer_candle, vol_mult = hammer
+
+    entry = hammer_candle[4]
+    stop = hammer_candle[3] * 0.999  # odmah ispod fitilja
+    target = find_target(htf, entry)
+    if target is None:
+        return None, "nema equal highs / swing higha iznad za TP"
+
+    risk = entry - stop
+    reward = target - entry
+    if risk <= 0:
+        return None, "nevaljan SL (iznad entryja)"
+    rr = reward / risk
+    if rr < MIN_RR:
+        return None, f"R:R {rr:.2f} < {MIN_RR} → preskačem (playbook pravilo)"
+
+    return Signal(
+        symbol=symbol,
+        time=utcnow(),
+        level=round(level, 8),
+        sweep_low=round(sweep_low, 8),
+        entry=round(entry, 8),
+        stop=round(stop, 8),
+        target=round(target, 8),
+        rr=round(rr, 2),
+        hammer_volume_mult=round(vol_mult, 2),
+        note=f"sweep dna ({touches} dodira) + stopping volume {vol_mult:.1f}x na {LTF}",
+    ), None
+
+
+# ---------------------------------------------------------------- journal
+
+
+def load_journal():
+    if os.path.exists(JOURNAL):
+        with open(JOURNAL) as f:
+            return json.load(f)
+    return {"balance": PAPER_BALANCE_START, "open": [], "closed": []}
+
+
+def save_journal(j):
+    with open(JOURNAL, "w") as f:
+        json.dump(j, f, indent=2)
+
+
+def paper_enter(journal, sig: Signal):
+    """Upiši paper trade: size po formuli (račun × rizik%) / udaljenost stopa."""
+    already = any(t["symbol"] == sig.symbol for t in journal["open"])
+    if already:
+        return False
+    risk_amount = journal["balance"] * RISK_PCT
+    stop_dist = (sig.entry - sig.stop) / sig.entry
+    size_quote = risk_amount / stop_dist if stop_dist > 0 else 0
+    journal["open"].append({**asdict(sig), "size_quote": round(size_quote, 2)})
+    return True
+
+
+def paper_update(journal, exchange):
+    """Provjeri otvorene paper tradeove: SL ili TP pogođen?"""
+    still_open = []
+    for t in journal["open"]:
+        ticker = exchange.fetch_ticker(t["symbol"])
+        px = ticker["last"]
+        result = None
+        if px <= t["stop"]:
+            result = ("SL", -journal["balance"] * RISK_PCT)
+        elif px >= t["target"]:
+            result = ("TP", journal["balance"] * RISK_PCT * t["rr"])
+        if result:
+            outcome, pnl = result
+            journal["balance"] = round(journal["balance"] + pnl, 2)
+            journal["closed"].append({**t, "outcome": outcome, "pnl": round(pnl, 2),
+                                      "closed_at": utcnow()})
+            print(f"[{utcnow()}] {t['symbol']} {outcome} pnl={pnl:+.2f} "
+                  f"balance={journal['balance']:.2f}")
+        else:
+            still_open.append(t)
+    journal["open"] = still_open
+
+
+# ---------------------------------------------------------------- live guard
+
+
+def live_execution_allowed() -> bool:
+    return (
+        os.environ.get("LIVE_TRADING") == "YES_I_UNDERSTAND"
+        and os.environ.get("EXCHANGE_API_KEY")
+        and os.environ.get("EXCHANGE_SECRET")
+    )
+
+
+def maybe_execute_live(exchange, sig: Signal):
+    """Pravi nalog SAMO uz eksplicitni opt-in. Inače ništa."""
+    if not live_execution_allowed():
+        return
+    print(f"[LIVE] šaljem limit buy {sig.symbol} @ {sig.entry} (SL {sig.stop} / TP {sig.target})")
+    # Namjerno minimalno: limit entry; SL/TP nalozi ovise o burzi (OCO itd.)
+    # pa ih postavi ručno ili proširi ovdje za svoju burzu.
+    balance = exchange.fetch_balance()
+    quote = sig.symbol.split("/")[1]
+    free = balance.get(quote, {}).get("free", 0)
+    risk_amount = free * RISK_PCT
+    stop_dist = (sig.entry - sig.stop) / sig.entry
+    amount = (risk_amount / stop_dist) / sig.entry if stop_dist > 0 else 0
+    if amount <= 0:
+        print("[LIVE] nema salda ili nevaljan sizing — preskačem")
+        return
+    exchange.create_order(sig.symbol, "limit", "buy", amount, sig.entry)
+    print(f"[LIVE] nalog poslan: {amount:.6f} {sig.symbol} @ {sig.entry}. "
+          f"POSTAVI SL/TP RUČNO na burzi!")
+
+
+# ---------------------------------------------------------------- modovi
+
+
+def make_exchange():
+    cls = getattr(ccxt, EXCHANGE_ID)
+    cfg = {"enableRateLimit": True}
+    if live_execution_allowed():
+        cfg["apiKey"] = os.environ["EXCHANGE_API_KEY"]
+        cfg["secret"] = os.environ["EXCHANGE_SECRET"]
+    return cls(cfg)
+
+
+def cmd_scan(symbols):
+    ex = make_exchange()
+    journal = load_journal()
+    for sym in symbols:
+        sig, reason = scan_symbol(ex, sym)
+        if sig:
+            print(f"\n🟢 SIGNAL {sym}\n{json.dumps(asdict(sig), indent=2)}")
+            if paper_enter(journal, sig):
+                print(f"→ paper trade upisan (journal: {JOURNAL})")
+            maybe_execute_live(ex, sig)
+        else:
+            print(f"— {sym}: {reason}")
+    paper_update(journal, ex)
+    save_journal(journal)
+
+
+def cmd_watch(symbols, interval=60):
+    ex = make_exchange()
+    mode = "LIVE" if live_execution_allowed() else "PAPER"
+    print(f"[{utcnow()}] watch mode ({mode}) — {', '.join(symbols)} svakih {interval}s. Ctrl+C za stop.")
+    while True:
+        journal = load_journal()
+        for sym in symbols:
+            try:
+                sig, reason = scan_symbol(ex, sym)
+                if sig:
+                    print(f"\n🟢 [{utcnow()}] SIGNAL {sym}: entry {sig.entry} SL {sig.stop} "
+                          f"TP {sig.target} R:R {sig.rr} ({sig.note})")
+                    if paper_enter(journal, sig):
+                        print("→ paper trade upisan")
+                    maybe_execute_live(ex, sig)
+            except ccxt.BaseError as e:
+                print(f"[{utcnow()}] {sym}: greška burze: {e}")
+        try:
+            paper_update(journal, ex)
+        except ccxt.BaseError as e:
+            print(f"[{utcnow()}] update greška: {e}")
+        save_journal(journal)
+        time.sleep(interval)
+
+
+def cmd_backtest(symbol):
+    """Grubi walk-forward test setupa na HTF povijesti (bez LTF preciznosti).
+
+    Aproksimacija: hammer tražimo na HTF svijećama umjesto na LTF (nemamo
+    poravnatu LTF povijest u jednom fetchu) — rezultati su konzervativna
+    donja granica, služe za osjećaj hit-ratea, ne za preciznu statistiku.
+    """
+    ex = make_exchange()
+    candles = fetch(ex, symbol, HTF, 1000)
+    wins = losses = 0
+    balance = PAPER_BALANCE_START
+    i = 100
+    while i < len(candles) - 50:
+        window = candles[:i]
+        level_info = find_liquidity_level(window[-HTF_CANDLES:])
+        if not level_info:
+            i += 1
+            continue
+        level, _ = level_info
+        sweep = detect_sweep(window[-HTF_CANDLES:], level)
+        if not sweep:
+            i += 1
+            continue
+        ok, vol_mult = is_stopping_volume_hammer(window[-1], [c[5] for c in window[:-1]])
+        if not (ok and window[-1][3] <= level * (1 + EQUAL_LOW_TOLERANCE)):
+            i += 1
+            continue
+        entry = window[-1][4]
+        stop = window[-1][3] * 0.999
+        target = find_target(window[-HTF_CANDLES:], entry)
+        if not target or (target - entry) / (entry - stop) < MIN_RR:
+            i += 1
+            continue
+        # odigraj naprijed
+        rr = (target - entry) / (entry - stop)
+        outcome = None
+        for j in range(i, min(i + 200, len(candles))):
+            if candles[j][3] <= stop:
+                outcome = "SL"
+                break
+            if candles[j][2] >= target:
+                outcome = "TP"
+                break
+        if outcome == "TP":
+            wins += 1
+            balance *= 1 + RISK_PCT * rr
+        elif outcome == "SL":
+            losses += 1
+            balance *= 1 - RISK_PCT
+        i += 10  # ne broji isti setup više puta
+    total = wins + losses
+    wr = wins / total * 100 if total else 0
+    print(f"\nBacktest {symbol} ({HTF}, ~{len(candles)} svijeća)")
+    print(f"tradeova: {total}  win: {wins}  loss: {losses}  win-rate: {wr:.1f}%")
+    print(f"balans: {PAPER_BALANCE_START:.0f} → {balance:.2f} "
+          f"({(balance / PAPER_BALANCE_START - 1) * 100:+.1f}%)")
+    print("Napomena: HTF aproksimacija hammera — konzervativna donja granica.")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+    mode, symbols = sys.argv[1], sys.argv[2:]
+    if mode == "scan":
+        cmd_scan(symbols)
+    elif mode == "watch":
+        cmd_watch(symbols)
+    elif mode == "backtest":
+        cmd_backtest(symbols[0])
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/trading-bot/requirements.txt
+++ b/trading-bot/requirements.txt
@@ -1,0 +1,4 @@
+anthropic>=0.45.0
+discord.py>=2.4.0
+python-dotenv>=1.0.1
+aiohttp>=3.10.0

--- a/trading-bot/requirements.txt
+++ b/trading-bot/requirements.txt
@@ -2,3 +2,4 @@ anthropic>=0.45.0
 discord.py>=2.4.0
 python-dotenv>=1.0.1
 aiohttp>=3.10.0
+ccxt>=4.3.0

--- a/trading-bot/tv_webhook.py
+++ b/trading-bot/tv_webhook.py
@@ -1,0 +1,118 @@
+"""TradingView alert webhook prijemnik.
+
+TradingView nema javni API za čitanje podataka — ali može SLATI webhook
+kad se tvoj alert okine. Ovaj server prima te alerte, upisuje ih u
+tv_alerts.json i (opcionalno) prosljeđuje u Discord kanal.
+
+Postavka na TradingView strani (treba plaćeni plan — Essential ili viši):
+  1. Otvori chart → Alert (zvonce) → uvjet po želji (npr. cijena probije dno).
+  2. U "Notifications" uključi "Webhook URL" i upiši:
+       http://TVOJA-JAVNA-ADRESA:8080/webhook
+  3. U "Message" polje zalijepi JSON (TradingView sam popuni {{...}}):
+       {"secret": "TVOJ_SECRET", "symbol": "{{ticker}}",
+        "price": "{{close}}", "timeframe": "{{interval}}",
+        "message": "sweep dna — provjeri stopping volume"}
+
+Server mora biti javno dostupan: VPS, port-forward na routeru, ili
+Cloudflare Tunnel / ngrok ako si doma iza NAT-a.
+
+Pokretanje:
+  WEBHOOK_SECRET=nesto-tajno python tv_webhook.py
+  # opcionalno: DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+  # opcionalno: PORT=8080
+
+Edukativni alat, nije financijski savjet.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import aiohttp
+from aiohttp import web
+
+PORT = int(os.environ.get("PORT", "8080"))
+SECRET = os.environ.get("WEBHOOK_SECRET", "")
+DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL", "")
+ALERTS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tv_alerts.json")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+log = logging.getLogger("tv-webhook")
+
+
+def utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def append_alert(alert: dict):
+    alerts = []
+    if os.path.exists(ALERTS_FILE):
+        with open(ALERTS_FILE) as f:
+            alerts = json.load(f)
+    alerts.append(alert)
+    with open(ALERTS_FILE, "w") as f:
+        json.dump(alerts, f, indent=2)
+
+
+async def forward_to_discord(alert: dict):
+    if not DISCORD_WEBHOOK_URL:
+        return
+    content = (
+        f"📡 **TradingView alert** — {alert.get('symbol', '?')} "
+        f"({alert.get('timeframe', '?')})\n"
+        f"Cijena: `{alert.get('price', '?')}`\n"
+        f"{alert.get('message', '')}\n"
+        f"_{alert['received_at']}_"
+    )
+    async with aiohttp.ClientSession() as session:
+        async with session.post(DISCORD_WEBHOOK_URL, json={"content": content}) as resp:
+            if resp.status >= 300:
+                log.warning("Discord forward failed: %s", resp.status)
+
+
+async def handle_webhook(request: web.Request) -> web.Response:
+    try:
+        # TradingView šalje body kao text — probaj JSON, fallback na plain text
+        raw = await request.text()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = {"message": raw}
+
+        # secret iz JSON-a ili query stringa (TradingView ne može slati headere)
+        supplied = data.get("secret") or request.query.get("secret") or ""
+        if not SECRET or supplied != SECRET:
+            log.warning("odbijen alert — pogrešan ili nedostajući secret")
+            return web.Response(status=403, text="forbidden")
+
+        data.pop("secret", None)
+        alert = {**data, "received_at": utcnow()}
+        append_alert(alert)
+        log.info("alert: %s @ %s — %s",
+                 alert.get("symbol", "?"), alert.get("price", "?"),
+                 alert.get("message", ""))
+        await forward_to_discord(alert)
+        return web.Response(text="ok")
+    except Exception:
+        log.exception("greška u obradi alerta")
+        return web.Response(status=500, text="error")
+
+
+async def handle_health(request: web.Request) -> web.Response:
+    return web.Response(text="tv-webhook up")
+
+
+def main():
+    if not SECRET:
+        raise SystemExit("Postavi WEBHOOK_SECRET env varijablu (bilo koji tajni string) pa pokreni ponovo.")
+    app = web.Application()
+    app.router.add_post("/webhook", handle_webhook)
+    app.router.add_get("/health", handle_health)
+    log.info("slušam na 0.0.0.0:%s /webhook (alerti → %s%s)",
+             PORT, ALERTS_FILE, ", + Discord" if DISCORD_WEBHOOK_URL else "")
+    web.run_app(app, port=PORT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Drop a chart image into a Discord channel and the bot replies with a
structured analysis: verdict, per-indicator reasoning (S/R, order book,
volume, MA, L99, bias), SAFE/RISKY/BAD safety rating, and a trade plan
with entry/SL/TP/R:R. L99 setup is described by the user in the message
caption; the bot does not invent L99 rules.

Uses adaptive thinking on the vision model and caches the system prompt
on every call.

https://claude.ai/code/session_015Gpri46FTmnkxV9GfghVj6